### PR TITLE
feat: prevent duplicate data items and enrich landing

### DIFF
--- a/src/app/components/data-item-container/data-item-container.component.html
+++ b/src/app/components/data-item-container/data-item-container.component.html
@@ -1,12 +1,12 @@
 <div class="border rounded-xl shadow p-4 bg-white mb-4">
-  <!-- Composant dynamique -->
-    @if (componentType === 'price') {
+  @switch (item.type) {
+    @case ('price') {
       <app-price-table [data]="item" />
     }
-    @if (componentType === 'text') {
+    @case ('text') {
       <app-text-block [data]="item" />
     }
-
+  }
   <div class="flex justify-end gap-2 mt-4">
     <button class="text-sm text-red-600 hover:underline" (click)="onDelete()">🗑 Supprimer</button>
     <button class="text-sm text-blue-600 hover:underline" (click)="onSave()">💾 Sauvegarder</button>

--- a/src/app/components/data-item-container/data-item-container.component.html
+++ b/src/app/components/data-item-container/data-item-container.component.html
@@ -1,8 +1,11 @@
 <div class="border rounded-xl shadow p-4 bg-white mb-4">
   <!-- Composant dynamique -->
-  @if (componentType === 'price') {
-    <app-price-table [data]="item" />
-  }
+    @if (componentType === 'price') {
+      <app-price-table [data]="item" />
+    }
+    @if (componentType === 'text') {
+      <app-text-block [data]="item" />
+    }
 
   <div class="flex justify-end gap-2 mt-4">
     <button class="text-sm text-red-600 hover:underline" (click)="onDelete()">🗑 Supprimer</button>

--- a/src/app/components/data-item-container/data-item-container.component.ts
+++ b/src/app/components/data-item-container/data-item-container.component.ts
@@ -1,14 +1,15 @@
 import { Component, Input } from '@angular/core';
 import { AnyDataItems } from '../../interfaces/dataItem.interface';
 import { CommonModule } from '@angular/common';
-import {PriceTableComponent} from '../specialized-data/PriceTable/price-table.component';
-import {Store} from '@ngrx/store';
-import {removeFromDisplay, saveFromDisplay} from '../../store/Data/dataState.actions';
+import { PriceTableComponent } from '../specialized-data/PriceTable/price-table.component';
+import { TextBlockComponent } from '../specialized-data/TextBlock/text-block.component';
+import { Store } from '@ngrx/store';
+import { removeFromDisplay, saveFromDisplay } from '../../store/Data/dataState.actions';
 
 @Component({
   selector: 'app-data-item-container',
   standalone: true,
-  imports: [CommonModule, PriceTableComponent],
+  imports: [CommonModule, PriceTableComponent, TextBlockComponent],
   templateUrl: './data-item-container.component.html',
 })
 export class DataItemContainerComponent {
@@ -20,6 +21,8 @@ export class DataItemContainerComponent {
     switch (this.item.type) {
       case 'price':
         return 'price';
+      case 'text':
+        return 'text';
       default:
         return null;
     }

--- a/src/app/components/data-item-container/data-item-container.component.ts
+++ b/src/app/components/data-item-container/data-item-container.component.ts
@@ -17,17 +17,6 @@ export class DataItemContainerComponent {
 
   constructor(private readonly store: Store) {}
 
-  get componentType() {
-    switch (this.item.type) {
-      case 'price':
-        return 'price';
-      case 'text':
-        return 'text';
-      default:
-        return null;
-    }
-  }
-
   onDelete() {
     console.log(this.item);
     this.store.dispatch(removeFromDisplay(this.item))

--- a/src/app/components/specialized-data/TextBlock/text-block.component.html
+++ b/src/app/components/specialized-data/TextBlock/text-block.component.html
@@ -1,0 +1,31 @@
+<section class="flex flex-col gap-4">
+  @switch (data.id) {
+    @case ('club-guide') {
+      <div>
+        <h3 class="text-lg font-semibold">Créer un club</h3>
+        <ol class="list-decimal list-inside flex flex-col gap-2">
+          <li>Créez votre compte pour démarrer.</li>
+          <li>Créez un club puis ajoutez vos équipes et joueurs.</li>
+        </ol>
+      </div>
+    }
+    @case ('cgu') {
+      <div>
+        <h3 class="text-lg font-semibold">Conditions générales d'utilisation</h3>
+        <p>Consultez nos CGU pour comprendre l'utilisation du service.</p>
+      </div>
+    }
+    @case ('upcoming-features') {
+      <div>
+        <h3 class="text-lg font-semibold">Fonctionnalités à venir</h3>
+        <ul class="list-disc list-inside flex flex-col gap-1">
+          <li>Analyse vidéo automatisée à bas prix.</li>
+          <li>Outil complet de gestion de club.</li>
+          <li>Partage de statistiques avec vos joueurs.</li>
+          <li>Support multi-langue et export de rapports.</li>
+        </ul>
+      </div>
+    }
+  }
+</section>
+

--- a/src/app/components/specialized-data/TextBlock/text-block.component.ts
+++ b/src/app/components/specialized-data/TextBlock/text-block.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DataItemBase } from '../../../interfaces/dataItem.interface';
+
+@Component({
+  selector: 'app-text-block',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './text-block.component.html',
+})
+export class TextBlockComponent {
+  @Input() data!: DataItemBase;
+}
+

--- a/src/app/enum/state.enum.ts
+++ b/src/app/enum/state.enum.ts
@@ -6,4 +6,5 @@ export enum DataItemState {
 
 export enum DataItemType {
   Price = 'price',
+  Text = 'text',
 }

--- a/src/app/interfaces/dataItem.interface.ts
+++ b/src/app/interfaces/dataItem.interface.ts
@@ -1,13 +1,16 @@
-import {DataItemState, DataItemType} from '../enum/state.enum';
-
-
-export type AnyDataItems = PriceTableData;
+import { DataItemState, DataItemType } from '../enum/state.enum';
 
 export interface DataItemBase {
   id: string;
   type: DataItemType;
   state: DataItemState;
 }
+
+export interface TextData extends DataItemBase {
+  type: DataItemType.Text;
+}
+
+export type AnyDataItems = PriceTableData | TextData;
 
 // Price Table Entry
 export interface PriceOption {
@@ -22,3 +25,4 @@ export interface PriceTableData extends DataItemBase {
   type: DataItemType.Price;
   plans: PriceOption[];
 }
+

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -1,7 +1,42 @@
 <div class="h-full flex flex-col gap-16 justify-center items-center">
-    <span class="light-text text-center text-4xl m-8"> Bienvenue sur l'application web ! </span>
-    <section class="flex flex-col justify-center items-center gap-2 bg-layer-2 rounded-3xl accent-text p-8">
-      <h3>Découvrez ici l'application</h3>
-      <a routerLink="/discover">svg Arrow</a>
-    </section >
+  <span class="light-text text-center text-4xl m-8">
+    Bienvenue sur l'application web !
+  </span>
+
+  <p class="max-w-xl text-center">
+    Cette plateforme a pour objectif de proposer une analyse vidéo abordable et un
+    outil de gestion de club simple à utiliser. Elle évoluera avec de nombreuses
+    fonctionnalités pour vous accompagner au quotidien.
+  </p>
+
+  <button
+    type="button"
+    (click)="toggleTutorial()"
+    class="px-4 py-2 rounded-md bg-layer-2 accent-text"
+  >
+    {{ showTutorial() ? 'Masquer le tutoriel' : 'Afficher le tutoriel' }}
+  </button>
+
+  @if (showTutorial()) {
+    <section class="flex flex-col gap-4 bg-layer-2 rounded-3xl accent-text p-8 max-w-xl">
+      <h3 class="text-lg font-semibold text-center">Tutoriel de démarrage</h3>
+      <ol class="list-decimal list-inside flex flex-col gap-2">
+        <li>Créez votre compte pour démarrer.</li>
+        <li>Créez un club puis ajoutez vos équipes et joueurs.</li>
+        <li>Consultez nos CGU pour comprendre l'utilisation du service.</li>
+      </ol>
+      <h4 class="text-md font-semibold">Fonctionnalités à venir</h4>
+      <ul class="list-disc list-inside flex flex-col gap-1">
+        <li>Analyse vidéo automatisée à bas prix.</li>
+        <li>Outil complet de gestion de club.</li>
+        <li>Partage de statistiques avec vos joueurs.</li>
+        <li>Support multi-langue et export de rapports.</li>
+      </ul>
+    </section>
+  }
+
+  <section class="flex flex-col justify-center items-center gap-2 bg-layer-2 rounded-3xl accent-text p-8">
+    <h3>Découvrez ici l'application</h3>
+    <a routerLink="/discover">svg Arrow</a>
+  </section>
 </div>

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -9,34 +9,8 @@
     fonctionnalités pour vous accompagner au quotidien.
   </p>
 
-  <button
-    type="button"
-    (click)="toggleTutorial()"
-    class="px-4 py-2 rounded-md bg-layer-2 accent-text"
-  >
-    {{ showTutorial() ? 'Masquer le tutoriel' : 'Afficher le tutoriel' }}
-  </button>
-
-  @if (showTutorial()) {
-    <section class="flex flex-col gap-4 bg-layer-2 rounded-3xl accent-text p-8 max-w-xl">
-      <h3 class="text-lg font-semibold text-center">Tutoriel de démarrage</h3>
-      <ol class="list-decimal list-inside flex flex-col gap-2">
-        <li>Créez votre compte pour démarrer.</li>
-        <li>Créez un club puis ajoutez vos équipes et joueurs.</li>
-        <li>Consultez nos CGU pour comprendre l'utilisation du service.</li>
-      </ol>
-      <h4 class="text-md font-semibold">Fonctionnalités à venir</h4>
-      <ul class="list-disc list-inside flex flex-col gap-1">
-        <li>Analyse vidéo automatisée à bas prix.</li>
-        <li>Outil complet de gestion de club.</li>
-        <li>Partage de statistiques avec vos joueurs.</li>
-        <li>Support multi-langue et export de rapports.</li>
-      </ul>
+    <section class="flex flex-col justify-center items-center gap-2 bg-layer-2 rounded-3xl accent-text p-8">
+      <h3>Découvrez ici l'application</h3>
+      <a routerLink="/discover">svg Arrow</a>
     </section>
-  }
-
-  <section class="flex flex-col justify-center items-center gap-2 bg-layer-2 rounded-3xl accent-text p-8">
-    <h3>Découvrez ici l'application</h3>
-    <a routerLink="/discover">svg Arrow</a>
-  </section>
-</div>
+  </div>

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 @Component({
@@ -11,10 +11,4 @@ import { RouterLink } from '@angular/router';
   ]
 })
 export class LandingComponent {
-  /** Signal permettant d'afficher ou non le tutoriel de démarrage */
-  readonly showTutorial = signal(false);
-
-  toggleTutorial(): void {
-    this.showTutorial.update(v => !v);
-  }
 }

--- a/src/app/pages/landing/landing.component.ts
+++ b/src/app/pages/landing/landing.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import {RouterLink} from '@angular/router';
+import { Component, signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-landing',
@@ -11,5 +11,10 @@ import {RouterLink} from '@angular/router';
   ]
 })
 export class LandingComponent {
+  /** Signal permettant d'afficher ou non le tutoriel de démarrage */
+  readonly showTutorial = signal(false);
 
+  toggleTutorial(): void {
+    this.showTutorial.update(v => !v);
+  }
 }

--- a/src/app/store/Data/dataState.reducers.ts
+++ b/src/app/store/Data/dataState.reducers.ts
@@ -60,8 +60,26 @@ const idleAppPrice = {
   state: DataItemState.Idle,
 }
 
+const clubGuide: AnyDataItems = {
+  id: 'club-guide',
+  type: DataItemType.Text,
+  state: DataItemState.Idle,
+};
+
+const cguInfo: AnyDataItems = {
+  id: 'cgu',
+  type: DataItemType.Text,
+  state: DataItemState.Idle,
+};
+
+const upcomingFeatures: AnyDataItems = {
+  id: 'upcoming-features',
+  type: DataItemType.Text,
+  state: DataItemState.Idle,
+};
+
 export const initialDataState: DataState = {
-  idle: [idleAppPrice],
+  idle: [idleAppPrice, clubGuide, cguInfo, upcomingFeatures],
   displayed: [appPrice],
   saved: [],
 };


### PR DESCRIPTION
## Summary
- avoid duplicate data items in store and correct save operations
- add project description and tutorial to landing page with Angular signals

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c9fad3c048326836b91238aa25e9b