### PR TITLE
feat: support display from saved state

### DIFF
--- a/src/app/components/data-item-container/Minified/mini.component.ts
+++ b/src/app/components/data-item-container/Minified/mini.component.ts
@@ -1,11 +1,11 @@
 import { Component, Input } from '@angular/core';
 import { Store } from '@ngrx/store';
 import { AnyDataItems } from '../../../interfaces/dataItem.interface';
-import {DataItemType} from '../../../enum/state.enum';
+import { DataItemState, DataItemType } from '../../../enum/state.enum';
 import {PriceTableMiniComponent} from '../../specialized-data/PriceTable/Minified/price-table-mini.component';
 import {TextBlockMiniComponent} from '../../specialized-data/TextBlock/Minified/text-block-mini.component';
 import {selectIdleItems} from '../../../store/Data/dataState.selectors';
-import {displayFromIdle} from '../../../store/Data/dataState.actions';
+import { displayFromIdle, displayFromSaved } from '../../../store/Data/dataState.actions';
 
 @Component({
   selector: 'app-mini',
@@ -19,11 +19,16 @@ import {displayFromIdle} from '../../../store/Data/dataState.actions';
 export class MiniComponent {
   @Input({required: true}) item!: AnyDataItems;
   protected readonly DataItemType = DataItemType;
+  protected readonly DataItemState = DataItemState;
 
   constructor(private readonly store: Store) {}
 
   displayData() {
     console.log(this.item.id);
-    this.store.dispatch(displayFromIdle(this.item))
+    if (this.item.state === DataItemState.Saved) {
+      this.store.dispatch(displayFromSaved(this.item));
+    } else if (this.item.state === DataItemState.Idle) {
+      this.store.dispatch(displayFromIdle(this.item));
+    }
   }
 }

--- a/src/app/store/Data/dataState.actions.ts
+++ b/src/app/store/Data/dataState.actions.ts
@@ -30,5 +30,11 @@ export const saveFromDisplay = createAction(
   props<{ id: string }>()
 );
 
+// SAVED ACTIONS
+export const displayFromSaved = createAction(
+  '[DataState] Display from saved',
+  props<{ id: string }>()
+);
+
 
 

--- a/src/app/store/Data/dataState.reducers.ts
+++ b/src/app/store/Data/dataState.reducers.ts
@@ -3,6 +3,7 @@ import { createReducer, on } from '@ngrx/store';
 import {
   addToIdle,
   displayFromIdle,
+  displayFromSaved,
   removeFromDisplay,
   removeFromIdle,
   saveFromDisplay,
@@ -145,6 +146,19 @@ export const dataStateReducer = createReducer(
       ...state,
       displayed: state.displayed.filter(el => el.id !== id),
       saved: [...state.saved, { ...item, state: DataItemState.Saved }],
+    };
+  }),
+
+  // SAVED PART
+  on(displayFromSaved, (state, { id }) => {
+    const item = state.saved.find(el => el.id === id);
+    // Ne rien faire si l'élément n'existe pas ou est déjà affiché
+    if (!item || state.displayed.some(el => el.id === id)) {
+      return state;
+    }
+    return {
+      ...state,
+      displayed: [...state.displayed, { ...item, state: DataItemState.Displayed }],
     };
   }),
 );


### PR DESCRIPTION
## Summary
- add displayFromSaved action and reducer
- dispatch displayFromSaved when mini items come from saved state

## Testing
- `npx ng test --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_689cc26cec808326bc2aa016250d33a1