### PR TITLE
fix: align data action payloads with reducers

### DIFF
--- a/src/app/components/data-item-container/Minified/mini.component.ts
+++ b/src/app/components/data-item-container/Minified/mini.component.ts
@@ -26,9 +26,9 @@ export class MiniComponent {
   displayData() {
     console.log(this.item.id);
     if (this.item.state === DataItemState.Saved) {
-      this.store.dispatch(displayFromSaved(this.item));
+      this.store.dispatch(displayFromSaved({ id: this.item.id }));
     } else if (this.item.state === DataItemState.Idle) {
-      this.store.dispatch(displayFromIdle(this.item));
+      this.store.dispatch(displayFromIdle({ id: this.item.id }));
     }
   }
 }

--- a/src/app/components/data-item-container/data-item-container.component.ts
+++ b/src/app/components/data-item-container/data-item-container.component.ts
@@ -19,11 +19,11 @@ export class DataItemContainerComponent {
 
   onDelete() {
     console.log(this.item);
-    this.store.dispatch(removeFromDisplay(this.item))
+    this.store.dispatch(removeFromDisplay({ id: this.item.id }));
   }
 
   onSave() {
     console.log(this.item);
-    this.store.dispatch(saveFromDisplay(this.item))
+    this.store.dispatch(saveFromDisplay({ id: this.item.id }));
   }
 }


### PR DESCRIPTION
## Summary
- dispatch `removeFromDisplay` and `saveFromDisplay` using `{id}`
- ensure `MiniComponent` sends id payloads for display actions

## Testing
- `npm run build`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*

------
https://chatgpt.com/codex/tasks/task_e_689ce11a1c7c83268c26a35f2ccdbd03