### PR TITLE
feat: add loading dots component

### DIFF
--- a/src/app/components/loading-dots/index.ts
+++ b/src/app/components/loading-dots/index.ts
@@ -1,0 +1,1 @@
+export * from './loading-dots.component';

--- a/src/app/components/loading-dots/loading-dots.component.ts
+++ b/src/app/components/loading-dots/loading-dots.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-loading-dots',
+  standalone: true,
+  template: `
+    <span class="flex items-center space-x-1">
+      <span class="dot w-2 h-2 bg-[currentColor] rounded-full"></span>
+      <span class="dot w-2 h-2 bg-[currentColor] rounded-full"></span>
+      <span class="dot w-2 h-2 bg-[currentColor] rounded-full"></span>
+    </span>
+  `,
+  styles: [
+    `
+    .dot {
+      animation: loading-dots 1.4s infinite both;
+    }
+    .dot:nth-child(1) {
+      animation-delay: -0.32s;
+    }
+    .dot:nth-child(2) {
+      animation-delay: -0.16s;
+    }
+    @keyframes loading-dots {
+      0%, 80%, 100% { opacity: 0; }
+      40% { opacity: 1; }
+    }
+    `,
+  ],
+})
+export class LoadingDotsComponent {}
+


### PR DESCRIPTION
## Summary
- add standalone `app-loading-dots` component with animated dots
- export component via index file for easy imports

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a04b78834883269166ac64e664ab1b