### PR TITLE
Add loading indicator to auth modal

### DIFF
--- a/src/app/core/shared/modals/auth/auth-modal.component.html
+++ b/src/app/core/shared/modals/auth/auth-modal.component.html
@@ -45,7 +45,17 @@
     }
 
     <div class="flex justify-around mt-8">
-      <button class="btn-accent p-2" type="submit">{{ this.modalType === 'login' ? 'Se connecter' : 'Inscription' }}</button>
+      @if (loading$ | async) {
+        <app-loading-dots />
+      } @else {
+        <button
+          class="btn-accent p-2"
+          type="submit"
+          [disabled]="form.invalid || (loading$ | async)"
+        >
+          {{ this.modalType === 'login' ? 'Se connecter' : 'Inscription' }}
+        </button>
+      }
       <button (click)="closeModal()" class="btn-accent p-2">Annuler</button>
     </div>
   </form>

--- a/src/app/core/shared/modals/auth/auth-modal.component.ts
+++ b/src/app/core/shared/modals/auth/auth-modal.component.ts
@@ -3,6 +3,9 @@ import {FormControl, FormGroup, ReactiveFormsModule, Validators} from '@angular/
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import {MatError, MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatInput} from '@angular/material/input';
+import { Store } from '@ngrx/store';
+import { LoadingDotsComponent } from '../../../../components/loading-dots';
+import { selectAuthLoading } from '../../../../store/auth/auth.selectors';
 import {
   digitValidator,
   lowercaseValidator,
@@ -18,7 +21,7 @@ interface AuthModalData {
 @Component({
   selector: 'app-auth-modal',
   templateUrl: './auth-modal.component.html',
-  imports: [MatFormField, MatLabel, MatInput, MatError, ReactiveFormsModule],
+  imports: [MatFormField, MatLabel, MatInput, MatError, ReactiveFormsModule, LoadingDotsComponent],
   standalone: true
 })
 export class AuthModalComponent {
@@ -28,6 +31,8 @@ export class AuthModalComponent {
 
   private dialogRef: MatDialogRef<AuthModalComponent> = inject(MatDialogRef);
   public data = inject<AuthModalData>(MAT_DIALOG_DATA);
+  private store = inject(Store);
+  readonly loading$ = this.store.select(selectAuthLoading);
 
   constructor(
   ) {

--- a/src/app/store/auth/auth.selectors.ts
+++ b/src/app/store/auth/auth.selectors.ts
@@ -1,0 +1,12 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+
+export interface AuthState {
+  loading: boolean;
+}
+
+export const selectAuthState = createFeatureSelector<AuthState>('auth');
+
+export const selectAuthLoading = createSelector(
+  selectAuthState,
+  (state) => state.loading
+);


### PR DESCRIPTION
## Summary
- show LoadingDotsComponent while auth form is submitting
- disable auth submit button when invalid or loading
- stub auth selectors for loading state

## Testing
- `npm run lint`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a04d5c18588326a267efec7236fc82