### PR TITLE
Improve auth flow and add 404 page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,9 +2,12 @@
 import { Routes } from '@angular/router';
 import { LandingComponent } from './pages/landing/landing.component';
 import { DiscoverComponent } from './pages/discover/discover.component';
+import { authGuard } from './core/guards/auth.guard';
+import { NotFoundComponent } from './pages/not-found/not-found.component';
 
 export const routes: Routes = [
   { path: '', component: LandingComponent },
   { path: 'discover', component: DiscoverComponent },
-  { path: 'welcome', component: DiscoverComponent },
+  { path: 'welcome', component: DiscoverComponent, canActivate: [authGuard] },
+  { path: '**', component: NotFoundComponent },
 ];

--- a/src/app/components/data-item-container/Minified/mini.component.html
+++ b/src/app/components/data-item-container/Minified/mini.component.html
@@ -1,7 +1,7 @@
 <div class="flex flex-col border rounded-md p-2 max-h-16 overflow-y-auto">
   <div class="flex gap-2">
     <span class="font-bold truncate">{{ item.id }}</span>
-    <button (click)="displayData()" class="btn-accent w-fit px-2 ml-auto">Afficher</button>
+    <button (click)="displayData()" class="btn-accent w-fit px-2 ml-auto" [disabled]="isDisplayed()">Afficher</button>
   </div>
 
   @switch (item.type) {

--- a/src/app/components/data-item-container/Minified/mini.component.ts
+++ b/src/app/components/data-item-container/Minified/mini.component.ts
@@ -5,6 +5,7 @@ import { DataItemState, DataItemType } from '../../../enum/state.enum';
 import {PriceTableMiniComponent} from '../../specialized-data/PriceTable/Minified/price-table-mini.component';
 import {TextBlockMiniComponent} from '../../specialized-data/TextBlock/Minified/text-block-mini.component';
 import { displayFromIdle, displayFromSaved } from '../../../store/Data/dataState.actions';
+import { selectDisplayedItems } from '../../../store/Data/dataState.selectors';
 
 @Component({
   selector: 'app-mini',
@@ -18,9 +19,17 @@ import { displayFromIdle, displayFromSaved } from '../../../store/Data/dataState
 export class MiniComponent {
   @Input({required: true}) item!: AnyDataItems;
   protected readonly DataItemType = DataItemType;
-  private readonly store = inject(Store)
+  private readonly store = inject(Store);
+  private readonly displayedItems = this.store.selectSignal(selectDisplayedItems);
+
+  isDisplayed(): boolean {
+    return this.displayedItems().some(item => item.id === this.item.id);
+  }
 
   displayData() {
+    if (this.isDisplayed()) {
+      return;
+    }
     if (this.item.state === DataItemState.Saved) {
       this.store.dispatch(displayFromSaved({ id: this.item.id }));
     } else if (this.item.state === DataItemState.Idle) {

--- a/src/app/core/guards/auth.guard.ts
+++ b/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,15 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { selectIsLoggedIn } from '../../store/User/user.selectors';
+import { map, take } from 'rxjs';
+
+export const authGuard: CanActivateFn = () => {
+  const store = inject(Store);
+  const router = inject(Router);
+
+  return store.select(selectIsLoggedIn).pipe(
+    take(1),
+    map(isLoggedIn => (isLoggedIn ? true : router.parseUrl('/')))
+  );
+};

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -5,12 +5,14 @@
     </div>
   </div>
   <nav class="flex justify-around min-w-1 mr-6 light-text">
-    @if (!isloggedIn) {
+    @if (!isloggedIn()) {
       <div class="flex gap-4">
         <button class="icon p-2" (click)="openAuthModal('login')">
           login
         </button>
       </div>
+    } @else {
+      <button class="icon p-2" (click)="logout()">Déconnexion</button>
     }
   </nav>
 </header>

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideMockStore } from '@ngrx/store/testing';
+import { MatDialogModule } from '@angular/material/dialog';
 
 import { HeaderComponent } from './header.component';
 
@@ -8,9 +10,10 @@ describe('HeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HeaderComponent]
+      imports: [HeaderComponent, MatDialogModule],
+      providers: [provideMockStore()]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,9 @@
 import {Component, inject, Input} from '@angular/core';
 import {MatDialog} from '@angular/material/dialog';
 import {AuthModalComponent} from '../core/shared/modals/auth/auth-modal.component';
+import {Store} from '@ngrx/store';
+import {logout} from '../store/User/user.actions';
+import {selectIsLoggedIn} from '../store/User/user.selectors';
 
 @Component({
   selector: 'app-header',
@@ -9,12 +12,17 @@ import {AuthModalComponent} from '../core/shared/modals/auth/auth-modal.componen
 })
 export class HeaderComponent {
   @Input({required: true}) currentSpace!: string;
-  protected readonly isloggedIn: boolean = false;
+  private readonly store = inject(Store);
+  protected readonly isloggedIn = this.store.selectSignal(selectIsLoggedIn);
   readonly dialog = inject(MatDialog);
 
   openAuthModal(type: 'login' | 'register'): void {
     this.dialog.open(AuthModalComponent, {
       data: { type }
     });
+  }
+
+  logout(): void {
+    this.store.dispatch(logout());
   }
 }

--- a/src/app/pages/not-found/not-found.component.html
+++ b/src/app/pages/not-found/not-found.component.html
@@ -1,0 +1,4 @@
+<div class="p-4 text-center">
+  <h1 class="text-2xl mb-4">404 - Page non trouvée</h1>
+  <p>La page demandée est introuvable.</p>
+</div>

--- a/src/app/pages/not-found/not-found.component.ts
+++ b/src/app/pages/not-found/not-found.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-not-found',
+  standalone: true,
+  templateUrl: './not-found.component.html'
+})
+export class NotFoundComponent {}

--- a/src/app/store/User/user.effects.ts
+++ b/src/app/store/User/user.effects.ts
@@ -64,7 +64,10 @@ export class UserEffects {
     () =>
       this.actions$.pipe(
         ofType(logout),
-        tap(() => this.tokenService.clearTokens())
+        tap(() => {
+          this.tokenService.clearTokens();
+          this.router.navigate(['/']);
+        })
       ),
     { dispatch: false }
   );

--- a/src/app/store/User/user.selectors.ts
+++ b/src/app/store/User/user.selectors.ts
@@ -17,3 +17,8 @@ export const selectAuthLoading = createSelector(
   selectUserState,
   state => state.loading
 );
+
+export const selectIsLoggedIn = createSelector(
+  selectUserState,
+  state => !!state.email && !!state.tokens
+);


### PR DESCRIPTION
## Summary
- disable mini item display button when already shown
- add auth guard for welcome route and simple 404 page
- replace login button with logout when authenticated
- redirect home on logout to enforce guard

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0650646548326bfc9ea5b73146232