### PR TITLE
feat: add welcome page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,12 +2,13 @@
 import { Routes } from '@angular/router';
 import { LandingComponent } from './pages/landing/landing.component';
 import { DiscoverComponent } from './pages/discover/discover.component';
+import { WelcomeComponent } from './pages/welcome/welcome.component';
 import { authGuard } from './core/guards/auth.guard';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 
 export const routes: Routes = [
   { path: '', component: LandingComponent },
   { path: 'discover', component: DiscoverComponent },
-  { path: 'welcome', component: DiscoverComponent, canActivate: [authGuard] },
+  { path: 'welcome', component: WelcomeComponent, canActivate: [authGuard] },
   { path: '**', component: NotFoundComponent },
 ];

--- a/src/app/pages/welcome/welcome.component.html
+++ b/src/app/pages/welcome/welcome.component.html
@@ -1,0 +1,4 @@
+<div class="welcome-container flex flex-col items-center justify-center gap-4">
+  <button routerLink="/club" class="btn">Rejoindre/Trouver un club</button>
+  <button routerLink="/analyse" class="btn">Démarrer une analyse</button>
+</div>

--- a/src/app/pages/welcome/welcome.component.scss
+++ b/src/app/pages/welcome/welcome.component.scss
@@ -1,0 +1,3 @@
+.welcome-container {
+  height: 100%;
+}

--- a/src/app/pages/welcome/welcome.component.ts
+++ b/src/app/pages/welcome/welcome.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-welcome',
+  standalone: true,
+  templateUrl: './welcome.component.html',
+  styleUrl: './welcome.component.scss',
+  imports: [
+    RouterLink
+  ]
+})
+export class WelcomeComponent {}


### PR DESCRIPTION
## Summary
- add standalone welcome page with navigation buttons
- register welcome route with auth guard

## Testing
- `npm run lint`
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d1ffbe0c83269469cd1a453f79a0