### PR TITLE
feat: add analyse route and placeholders

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,10 +5,18 @@ import { DiscoverComponent } from './pages/discover/discover.component';
 import { WelcomeComponent } from './pages/welcome/welcome.component';
 import { authGuard } from './core/guards/auth.guard';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
+import { ServiceUnavailableComponent } from './components/service-unavailable/service-unavailable.component';
+import { AnalyseComponent } from './pages/analyse/analyse.component';
 
 export const routes: Routes = [
   { path: '', component: LandingComponent },
   { path: 'discover', component: DiscoverComponent },
   { path: 'welcome', component: WelcomeComponent, canActivate: [authGuard] },
+  { path: 'club', component: ServiceUnavailableComponent, canActivate: [authGuard] },
+  { path: 'teams', component: ServiceUnavailableComponent, canActivate: [authGuard] },
+  { path: 'players', component: ServiceUnavailableComponent, canActivate: [authGuard] },
+  { path: 'tournaments', component: ServiceUnavailableComponent, canActivate: [authGuard] },
+  { path: 'matchs', component: ServiceUnavailableComponent, canActivate: [authGuard] },
+  { path: 'analyse', component: AnalyseComponent, canActivate: [authGuard] },
   { path: '**', component: NotFoundComponent },
 ];

--- a/src/app/pages/analyse/analyse.component.html
+++ b/src/app/pages/analyse/analyse.component.html
@@ -1,0 +1,1 @@
+<p>Analyse works!</p>

--- a/src/app/pages/analyse/analyse.component.ts
+++ b/src/app/pages/analyse/analyse.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-analyse',
+  standalone: true,
+  templateUrl: './analyse.component.html',
+})
+export class AnalyseComponent {}


### PR DESCRIPTION
## Summary
- add placeholder Analyse page
- guard new club and analyse routes

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e0216f5c8326a8ecd6194006b666