### PR TITLE
feat(header): add club menu navigation

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -12,7 +12,18 @@
         </button>
       </div>
     } @else {
-      <button class="icon p-2" (click)="logout()">Déconnexion</button>
+      <div class="flex gap-4 items-center">
+        <button mat-button [matMenuTriggerFor]="clubMenu">Club</button>
+        <mat-menu #clubMenu="matMenu">
+          <button mat-menu-item routerLink="/club">Club</button>
+          <button mat-menu-item routerLink="/teams">Teams</button>
+          <button mat-menu-item routerLink="/players">Players</button>
+          <button mat-menu-item routerLink="/tournaments">Tournaments</button>
+          <button mat-menu-item routerLink="/matchs">Matchs</button>
+        </mat-menu>
+        <button mat-button routerLink="/analyse">Analyse</button>
+        <button class="icon p-2" (click)="logout()">Déconnexion</button>
+      </div>
     }
   </nav>
 </header>

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideMockStore } from '@ngrx/store/testing';
 import { MatDialogModule } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { HeaderComponent } from './header.component';
 
@@ -10,7 +11,7 @@ describe('HeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HeaderComponent, MatDialogModule],
+      imports: [HeaderComponent, MatDialogModule, RouterTestingModule],
       providers: [provideMockStore()]
     })
       .compileComponents();

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,4 +1,7 @@
 import {Component, inject, Input} from '@angular/core';
+import {RouterLink} from '@angular/router';
+import {MatButtonModule} from '@angular/material/button';
+import {MatMenuModule} from '@angular/material/menu';
 import {MatDialog} from '@angular/material/dialog';
 import {AuthModalComponent} from '../core/shared/modals/auth/auth-modal.component';
 import {Store} from '@ngrx/store';
@@ -9,6 +12,7 @@ import {selectIsLoggedIn} from '../store/User/user.selectors';
   selector: 'app-header',
   templateUrl: './header.component.html',
   standalone: true,
+  imports: [MatMenuModule, MatButtonModule, RouterLink],
 })
 export class HeaderComponent {
   @Input({required: true}) currentSpace!: string;


### PR DESCRIPTION
## Summary
- add club menu with links to club sections
- show analyse link and logout for authenticated users
- include required Angular Material and router imports

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0e19ad38c8326b898e428dd901042