### PR TITLE
feat(auth): refine login check and scaffold license guard

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
@@ -20,6 +21,7 @@ export const appConfig: ApplicationConfig = {
       dataState: dataStateReducer,
       userState: userReducer
     }),
-    provideEffects(UserEffects)
+    provideEffects(UserEffects),
+    provideHttpClient()
   ]
 };

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { LandingComponent } from './pages/landing/landing.component';
 import { DiscoverComponent } from './pages/discover/discover.component';
 import { WelcomeComponent } from './pages/welcome/welcome.component';
 import { authGuard } from './core/guards/auth.guard';
+import { licenseGuard } from './core/guards/license.guard';
 import { NotFoundComponent } from './pages/not-found/not-found.component';
 import { ServiceUnavailableComponent } from './components/service-unavailable/service-unavailable.component';
 import { AnalyseComponent } from './pages/analyse/analyse.component';
@@ -17,6 +18,6 @@ export const routes: Routes = [
   { path: 'players', component: ServiceUnavailableComponent, canActivate: [authGuard] },
   { path: 'tournaments', component: ServiceUnavailableComponent, canActivate: [authGuard] },
   { path: 'matchs', component: ServiceUnavailableComponent, canActivate: [authGuard] },
-  { path: 'analyse', component: AnalyseComponent, canActivate: [authGuard] },
+  { path: 'analyse', component: AnalyseComponent, canActivate: [authGuard, licenseGuard] },
   { path: '**', component: NotFoundComponent },
 ];

--- a/src/app/core/guards/license.guard.ts
+++ b/src/app/core/guards/license.guard.ts
@@ -1,0 +1,16 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import { catchError, map, of } from 'rxjs';
+
+// Guard placeholder for future license validation via micro-service
+export const licenseGuard: CanActivateFn = () => {
+  const http = inject(HttpClient);
+  const router = inject(Router);
+
+  // TODO: replace '/api/license/validate' with the actual license validation endpoint
+  return http.get<{ valid: boolean }>('/api/license/validate').pipe(
+    map(response => (response.valid ? true : router.parseUrl('/'))),
+    catchError(() => of(router.parseUrl('/')))
+  );
+};

--- a/src/app/store/User/user.selectors.ts
+++ b/src/app/store/User/user.selectors.ts
@@ -20,5 +20,8 @@ export const selectAuthLoading = createSelector(
 
 export const selectIsLoggedIn = createSelector(
   selectUserState,
-  state => !!state.email && !!state.tokens
+  state =>
+    !!state.email &&
+    !!state.tokens?.accessToken &&
+    !!state.tokens?.refreshToken
 );


### PR DESCRIPTION
## Summary
- require email plus access/refresh tokens to consider a user logged in
- wire up future license validation guard for /analyse
- register HttpClient for upcoming micro-service calls

## Testing
- `npm run lint`
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68a0e4c0ccb083269d417740ed47923c