### PR TITLE
feat: manage idle data via navigation effects

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -10,6 +10,7 @@ import { provideEffects } from '@ngrx/effects';
 import { dataStateReducer } from './store/Data/dataState.reducers';
 import { userReducer } from './store/User/user.reducer';
 import { UserEffects } from './store/User/user.effects';
+import { DataEffects } from './store/Data/dataState.effects';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -21,7 +22,7 @@ export const appConfig: ApplicationConfig = {
       dataState: dataStateReducer,
       userState: userReducer
     }),
-    provideEffects(UserEffects),
+    provideEffects(UserEffects, DataEffects),
     provideHttpClient()
   ]
 };

--- a/src/app/store/Data/dataState.actions.ts
+++ b/src/app/store/Data/dataState.actions.ts
@@ -19,6 +19,10 @@ export const saveFromIdle = createAction(
   props<{ id: string }>()
 );
 
+// ROUTE ACTIONS
+export const loadDiscoverData = createAction('[DataState] Load Discover Data');
+export const clearIdleData = createAction('[DataState] Clear Route Data');
+
 // DISPLAY ACTIONS
 export const removeFromDisplay = createAction(
   '[DataState] Remove from display',

--- a/src/app/store/Data/dataState.effects.ts
+++ b/src/app/store/Data/dataState.effects.ts
@@ -1,0 +1,25 @@
+import { inject, Injectable } from '@angular/core';
+import { createEffect } from '@ngrx/effects';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter, switchMap } from 'rxjs';
+import { loadDiscoverData, clearIdleData } from './dataState.actions';
+
+@Injectable()
+export class DataEffects {
+  private router = inject(Router);
+
+  routeChange$ = createEffect(() =>
+    this.router.events.pipe(
+      filter((event): event is NavigationEnd => event instanceof NavigationEnd),
+      switchMap(({ urlAfterRedirects }) => {
+        const actions = [clearIdleData()];
+        switch (urlAfterRedirects) {
+          case '/discover':
+            actions.push(loadDiscoverData());
+            break;
+        }
+        return actions;
+      })
+    )
+  );
+}

--- a/src/app/store/Data/dataState.reducers.ts
+++ b/src/app/store/Data/dataState.reducers.ts
@@ -2,8 +2,10 @@ import { AnyDataItems } from '../../interfaces/dataItem.interface';
 import { createReducer, on } from '@ngrx/store';
 import {
   addToIdle,
+  clearIdleData,
   displayFromIdle,
   displayFromSaved,
+  loadDiscoverData,
   removeFromDisplay,
   removeFromIdle,
   saveFromDisplay,
@@ -80,13 +82,23 @@ const upcomingFeatures: AnyDataItems = {
 };
 
 export const initialDataState: DataState = {
-  idle: [idleAppPrice, clubGuide, cguInfo, upcomingFeatures],
-  displayed: [appPrice],
+  idle: [],
+  displayed: [],
   saved: [],
 };
 
 export const dataStateReducer = createReducer(
   initialDataState,
+  on(loadDiscoverData, state => ({
+    ...state,
+    idle: [idleAppPrice, clubGuide, cguInfo, upcomingFeatures],
+    displayed: [appPrice],
+  })),
+  on(clearIdleData, state => ({
+    ...state,
+    idle: [],
+    displayed: [],
+  })),
   // IDLE PART
   on(addToIdle, (state, { item }) => {
     // Empêche l'ajout d'un élément déjà présent dans l'un des états


### PR DESCRIPTION
## Summary
- remove data guard and shift route handling to effects
- dispatch discover load or idle clearing actions on navigation
- register DataEffects and streamline route guards
- clear idle data on every route change before handling route-specific actions

## Testing
- `npm run build` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1c28a99848326876dd2efd508fd17