### PR TITLE
feat: toggle sidebar on analyse route

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,44 +1,44 @@
 <div class="w-dvw h-dvh flex flex-col">
   <app-header [currentSpace]="'Accueil'" />
 
-  <main class="flex flex-1 overflow-hidden">
-    <!-- Sidebar gauche : Idle + Saved -->
-    <section class="w-[20%] min-w-[200px] max-w-[300px] bg-layer-1 p-2 flex flex-col gap-4 overflow-y-auto">
-      <!-- IDLE -->
-      <div id="idle-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
-        <h2 class="text-sm font-semibold mb-2">🟡 Données en attente</h2>
-        @if (idleItems().length > 0) {
-          <div class="space-y-2">
-            @for (item of idleItems(); track item.id) {
-              <app-mini [item]="item"/>
-            }
-          </div>
-        } @else {
-          <p class="text-xs text-gray-500">Aucune donnée en attente.</p>
-        }
-      </div>
+  <main class="flex-1 overflow-hidden" [class.flex]="showSidebar">
+    <ng-container *ngIf="showSidebar">
+      <!-- Sidebar gauche : Idle + Saved -->
+      <section class="w-[20%] min-w-[200px] max-w-[300px] bg-layer-1 p-2 flex flex-col gap-4 overflow-y-auto">
+        <!-- IDLE -->
+        <div id="idle-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
+          <h2 class="text-sm font-semibold mb-2">🟡 Données en attente</h2>
+          @if (idleItems().length > 0) {
+            <div class="space-y-2">
+              @for (item of idleItems(); track item.id) {
+                <app-mini [item]="item"/>
+              }
+            </div>
+          } @else {
+            <p class="text-xs text-gray-500">Aucune donnée en attente.</p>
+          }
+        </div>
 
-      <!-- SAVED -->
-      <div id="saved-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
-        <h2 class="text-sm font-semibold mb-2">💾 Données sauvegardées</h2>
-        @if (savedItems().length > 0) {
-          <div class="space-y-2">
-            @for (item of savedItems(); track item.id) {
-              <app-mini [item]="item" />
-            }
-          </div>
-        } @else {
-          <p class="text-xs text-gray-500">Aucune donnée sauvegardée.</p>
-        }
-      </div>
-    </section>
+        <!-- SAVED -->
+        <div id="saved-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
+          <h2 class="text-sm font-semibold mb-2">💾 Données sauvegardées</h2>
+          @if (savedItems().length > 0) {
+            <div class="space-y-2">
+              @for (item of savedItems(); track item.id) {
+                <app-mini [item]="item" />
+              }
+            </div>
+          } @else {
+            <p class="text-xs text-gray-500">Aucune donnée sauvegardée.</p>
+          }
+        </div>
+      </section>
 
-    <div class="separator h-[80%] self-center mx-2">
-
-    </div>
+      <div class="separator h-[80%] self-center mx-2"></div>
+    </ng-container>
 
     <!-- Affichage principal -->
-    <section class="flex-1 p-2 overflow-y-auto">
+    <section class="p-2 overflow-y-auto" [class.flex-1]="showSidebar" [class.w-full]="!showSidebar">
       <router-outlet />
     </section>
   </main>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,11 @@
 import {Component, inject} from '@angular/core';
 import { HeaderComponent } from './header/header.component';
-import { RouterOutlet } from '@angular/router';
+import { NavigationEnd, Router, RouterOutlet } from '@angular/router';
 import { Store } from '@ngrx/store';
 import {MiniComponent} from './components/data-item-container/Minified/mini.component';
 import {selectIdleItems, selectSavedItems} from './store/Data/dataState.selectors';
 import { loadInitialState } from './store/User/user.actions';
+import {filter} from 'rxjs';
 
 @Component({
   selector: 'app-root',
@@ -15,9 +16,19 @@ import { loadInitialState } from './store/User/user.actions';
 })
 export class AppComponent {
   private readonly store = inject(Store);
+  private readonly router = inject(Router);
+
+  showSidebar = true;
 
   constructor() {
     this.store.dispatch(loadInitialState());
+
+    this.showSidebar = !this.router.url.startsWith('/analyse');
+    this.router.events
+      .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
+      .subscribe(({urlAfterRedirects}) => {
+        this.showSidebar = !urlAfterRedirects.startsWith('/analyse');
+      });
   }
 
   get idleItems() {


### PR DESCRIPTION
## Summary
- track router navigation to hide sidebar on `/analyse`
- conditionally render sidebar and expand main content

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1ef044cf083269ad0b53daba93c1e