### PR TITLE
feat: add draggable analysers

### DIFF
--- a/src/app/pages/analyse/analyse.component.html
+++ b/src/app/pages/analyse/analyse.component.html
@@ -1,1 +1,3 @@
-<p>Analyse works!</p>
+<app-video-player></app-video-player>
+<app-sequencer-panel></app-sequencer-panel>
+<app-timeline></app-timeline>

--- a/src/app/pages/analyse/analyse.component.ts
+++ b/src/app/pages/analyse/analyse.component.ts
@@ -1,8 +1,12 @@
 import { Component } from '@angular/core';
+import { VideoPlayerComponent } from './video-player.component';
+import { SequencerPanelComponent } from './sequencer-panel.component';
+import { TimelineComponent } from './timeline.component';
 
 @Component({
   selector: 'app-analyse',
   standalone: true,
   templateUrl: './analyse.component.html',
+  imports: [VideoPlayerComponent, SequencerPanelComponent, TimelineComponent],
 })
 export class AnalyseComponent {}

--- a/src/app/pages/analyse/sequencer-panel.component.html
+++ b/src/app/pages/analyse/sequencer-panel.component.html
@@ -1,0 +1,9 @@
+<div
+  appCdkDragResize
+  cdkDragBoundary="body"
+  [cdkDragFreeDragPosition]="dragPosition"
+  class="absolute resize overflow-auto"
+  style="top:0;right:0;width:30%;height:70%;"
+>
+  <!-- Sequencer content placeholder -->
+</div>

--- a/src/app/pages/analyse/sequencer-panel.component.scss
+++ b/src/app/pages/analyse/sequencer-panel.component.scss
@@ -1,0 +1,1 @@
+/* Styles for sequencer panel component */

--- a/src/app/pages/analyse/sequencer-panel.component.ts
+++ b/src/app/pages/analyse/sequencer-panel.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CdkDragResizeDirective } from '../../directives/cdk-drag-resize.directive';
+
+@Component({
+  selector: 'app-sequencer-panel',
+  standalone: true,
+  templateUrl: './sequencer-panel.component.html',
+  styleUrl: './sequencer-panel.component.scss',
+  imports: [CdkDragResizeDirective],
+})
+export class SequencerPanelComponent {
+  readonly dragPosition = { x: 0, y: 0 };
+}

--- a/src/app/pages/analyse/timeline.component.html
+++ b/src/app/pages/analyse/timeline.component.html
@@ -1,0 +1,9 @@
+<div
+  appCdkDragResize
+  cdkDragBoundary="body"
+  [cdkDragFreeDragPosition]="dragPosition"
+  class="absolute resize overflow-auto"
+  style="bottom:0;left:0;width:100%;height:30%;"
+>
+  <!-- Timeline content placeholder -->
+</div>

--- a/src/app/pages/analyse/timeline.component.scss
+++ b/src/app/pages/analyse/timeline.component.scss
@@ -1,0 +1,1 @@
+/* Styles for timeline component */

--- a/src/app/pages/analyse/timeline.component.ts
+++ b/src/app/pages/analyse/timeline.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CdkDragResizeDirective } from '../../directives/cdk-drag-resize.directive';
+
+@Component({
+  selector: 'app-timeline',
+  standalone: true,
+  templateUrl: './timeline.component.html',
+  styleUrl: './timeline.component.scss',
+  imports: [CdkDragResizeDirective],
+})
+export class TimelineComponent {
+  readonly dragPosition = { x: 0, y: 0 };
+}

--- a/src/app/pages/analyse/video-player.component.html
+++ b/src/app/pages/analyse/video-player.component.html
@@ -1,0 +1,9 @@
+<div
+  appCdkDragResize
+  cdkDragBoundary="body"
+  [cdkDragFreeDragPosition]="dragPosition"
+  class="absolute resize overflow-hidden"
+  style="top:0;left:0;width:70%;height:70%;"
+>
+  <!-- Video content placeholder -->
+</div>

--- a/src/app/pages/analyse/video-player.component.scss
+++ b/src/app/pages/analyse/video-player.component.scss
@@ -1,0 +1,1 @@
+/* Styles for video player component */

--- a/src/app/pages/analyse/video-player.component.ts
+++ b/src/app/pages/analyse/video-player.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { CdkDragResizeDirective } from '../../directives/cdk-drag-resize.directive';
+
+@Component({
+  selector: 'app-video-player',
+  standalone: true,
+  templateUrl: './video-player.component.html',
+  styleUrl: './video-player.component.scss',
+  imports: [CdkDragResizeDirective],
+})
+export class VideoPlayerComponent {
+  readonly dragPosition = { x: 0, y: 0 };
+}


### PR DESCRIPTION
## Summary
- add standalone video-player, sequencer-panel, and timeline components with drag/resize support
- integrate new components into analyse page

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint`
- `npm run build` *(errors: ReferenceError localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f1e52bc48326bec3cca25316db8c