### PR TITLE
Improve Timeline/Sequencer color UX, auto-contrast, and footer selection/undo

### DIFF
--- a/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.html
+++ b/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.html
@@ -9,7 +9,7 @@
         role="button"
         tabindex="0"
         class="absolute flex select-none flex-col items-center justify-center gap-1 overflow-hidden rounded-md border p-2 text-center"
-        [class.seq-btn-event]="btn.type === 'event'"
+        [class.seq-btn-event-card]="btn.type === 'event'"
         [class.seq-btn-label]="btn.type === 'label'"
         [class.seq-btn-event-active]="btn.type === 'event' && isActive(btn.id)"
         [ngStyle]="btnStyle(btn)"

--- a/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.ts
+++ b/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.ts
@@ -23,6 +23,7 @@ import {
   panDragThresholdPx,
 } from '../../../../utils/sequencer/sequencer-canvas-defaults.util';
 import { formatNormalizedHotkey } from '../../../../utils/sequencer/sequencer-hotkey-options.util';
+import { getReadableTextColor } from '../../../../utils/color/color-contrast.utils';
 
 @Component({
   selector: 'app-sequencer-canvas',
@@ -33,6 +34,7 @@ import { formatNormalizedHotkey } from '../../../../utils/sequencer/sequencer-ho
   imports: [CommonModule, MatButtonModule, MatIconModule],
 })
 export class SequencerCanvasComponent {
+  private readonly defaultEventColor = '#1F3D28';
   private readonly panelService = inject(SequencerPanelService);
 
   @Input({ required: true }) btnList: SequencerBtn[] = [];
@@ -100,13 +102,21 @@ export class SequencerCanvasComponent {
 
   btnStyle(btn: SequencerBtn) {
     const layout = this.ensureBtnLayout(btn);
-    return {
+    const style: Record<string, string> = {
       left: `${layout.x}px`,
       top: `${layout.y}px`,
       width: `${layout.w}px`,
       height: `${layout.h}px`,
       zIndex: `${layout.z ?? 1}`,
     };
+
+    if (btn.type === 'event') {
+      const background = btn.colorHex || this.defaultEventColor;
+      style['backgroundColor'] = background;
+      style['color'] = getReadableTextColor(background);
+    }
+
+    return style;
   }
 
   onViewportMouseDown(event: MouseEvent) {

--- a/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.html
+++ b/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.html
@@ -31,6 +31,11 @@
       </mat-form-field>
     </div>
 
+    <div class="flex items-center gap-3">
+      <label for="event-color" class="text-xs font-semibold">Couleur</label>
+      <input id="event-color" type="color" formControlName="colorHex" class="timeline-color-input" />
+    </div>
+
     @if (isEdit) {
       <div class="border-layer rounded-md border p-3">
         <h4 class="mb-3 text-[13px] font-semibold">Liens</h4>

--- a/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.scss
+++ b/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.scss
@@ -1,0 +1,8 @@
+.timeline-color-input {
+  width: 2.25rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid var(--border-layer);
+  border-radius: 0.375rem;
+  background: transparent;
+}

--- a/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.ts
@@ -70,6 +70,7 @@ export class CreateEventBtnDialogComponent {
       [Validators.required],
     ),
     name: new FormControl(this.data.btn?.name ?? '', [Validators.required]),
+    colorHex: new FormControl(this.data.btn?.colorHex ?? '#1F3D28', { nonNullable: true }),
     kind: new FormControl<'limited' | 'indefinite'>(this.data.btn?.eventProps.kind ?? 'limited', {
       nonNullable: true,
     }),
@@ -137,6 +138,7 @@ export class CreateEventBtnDialogComponent {
 
     const id = (this.form.controls.id.value ?? '').trim();
     const name = (this.form.controls.name.value ?? '').trim();
+    const colorHex = this.form.controls.colorHex.value;
     const kind = this.form.controls.kind.value ?? 'limited';
     const preMs = Math.max(0, Math.round((this.form.controls.preSec.value ?? 0) * 1000));
     const postMs = Math.max(0, Math.round((this.form.controls.postSec.value ?? 0) * 1000));
@@ -166,6 +168,7 @@ export class CreateEventBtnDialogComponent {
     if (this.isEdit) {
       this.panelService.updateBtn(id, {
         name,
+        colorHex,
         hotkeyNormalized,
         deactivateIds,
         activateIds,
@@ -175,6 +178,7 @@ export class CreateEventBtnDialogComponent {
       const created = this.panelService.addEventBtn({
         id,
         name,
+        colorHex,
         hotkeyNormalized,
         deactivateIds,
         activateIds,

--- a/src/app/components/analyse/timeline/timeline.component.html
+++ b/src/app/components/analyse/timeline/timeline.component.html
@@ -5,7 +5,6 @@
     <button class="btn-secondary" (click)="facade.setAutoFollow(!facade.autoFollow())">Auto-follow {{ facade.autoFollow() ? 'ON' : 'OFF' }}</button>
     <button class="btn-secondary" (click)="recenter()">Recentrer</button>
     <button class="btn-secondary" (click)="facade.playSelection()">Play selection</button>
-    <button class="btn-secondary" (click)="facade.undoShiftOrAlign()">Undo</button>
   </div>
 
   @if (facade.eventDefs().length === 0) {
@@ -42,14 +41,16 @@
               <div class="border-subtle absolute left-0 right-0 border-b" [style.top.px]="rulerHeightPx + rowIndex * rowHeightPx" [style.height.px]="rowHeightPx">
                 @for (occurrence of rowOccurrences(eventDef.id); track occurrence.id) {
                   <div
-                    class="timeline-occurrence border-timeline-occurrence bg-timeline-occurrence absolute top-1 h-8 cursor-pointer rounded border"
-                    [class.is-active]="facade.selectionIds().includes(occurrence.id)"
+                    class="timeline-occurrence border-timeline-occurrence absolute top-1 h-8 cursor-pointer rounded border"
+                    [class.timeline-occurrence-selected]="facade.selectionIds().includes(occurrence.id)"
                     [style.left.px]="occurrenceLeftPx(occurrence)"
                     [style.width.px]="occurrenceWidthPx(occurrence)"
+                    [ngStyle]="occurrenceStyle(occurrence)"
                     tabindex="0"
                     (click)="onOccurrenceClick(occurrence.id, $event)"
                     (keydown.enter)="onOccurrenceKeydown(occurrence.id, $event)"
                   >
+                    <span class="timeline-occurrence-label">{{ eventDef.name }}</span>
                     <span class="timeline-resize-handle left" (mousedown)="startResize(occurrence, 'start', $event)"></span>
                     <span class="timeline-resize-handle right" (mousedown)="startResize(occurrence, 'end', $event)"></span>
                   </div>
@@ -62,13 +63,17 @@
     </div>
 
     <div class="border-subtle bg-layer-2 flex items-center gap-2 border-t p-2 text-xs">
-      <span>Selection: {{ facade.selectionIds().length }}</span>
+      <span>Sélection : {{ facade.selectionIds().length }}</span>
+      <button class="btn-secondary" (click)="facade.toggleAllSelections()">
+        {{ facade.allOccurrencesSelected() ? 'Tout désélectionner' : 'Tout sélectionner' }}
+      </button>
       <button class="btn-secondary" (click)="nudgeSelection(-100)">-100ms</button>
       <button class="btn-secondary" (click)="nudgeSelection(100)">+100ms</button>
       <button class="btn-secondary" (click)="nudgeSelection(-1000)">-1s</button>
       <button class="btn-secondary" (click)="nudgeSelection(1000)">+1s</button>
       <button class="btn-secondary" (click)="facade.shift(1000, 'SELECTION')">Shift +1s</button>
       <button class="btn-secondary" (click)="facade.shift(1000, 'ALL')">Shift all +1s</button>
+      <button class="btn-secondary" (click)="facade.undoShiftOrAlign()" [disabled]="!facade.canUndoShiftOrAlign()">Annuler décalage</button>
     </div>
   }
 </div>

--- a/src/app/components/analyse/timeline/timeline.component.ts
+++ b/src/app/components/analyse/timeline/timeline.component.ts
@@ -9,6 +9,7 @@ import {
 import { TimelineFacadeService } from '../../../core/services/timeline-facade.service';
 import { TimebaseService } from '../../../core/services/timebase.service';
 import { TimelineOccurrence } from '../../../interfaces/timeline/timeline.interface';
+import { getReadableTextColor } from '../../../utils/color/color-contrast.utils';
 
 @Component({
   selector: 'app-timeline',
@@ -32,6 +33,7 @@ export class TimelineComponent implements OnDestroy {
 
   private readonly isProgrammaticScrollSignal = signal(false);
   private programmaticScrollTimeoutId?: number;
+  private readonly defaultEventColor = '#1F3D28';
 
   readonly contentWidthPx = computed(() => Math.max(1200, Math.ceil(this.facade.workDurationMs() * this.pxPerMs)));
   readonly contentHeightPx = computed(() => this.rulerHeightPx + this.facade.eventDefs().length * this.rowHeightPx);
@@ -176,6 +178,17 @@ export class TimelineComponent implements OnDestroy {
     return occurrence.startMs * this.pxPerMs;
   }
 
+  occurrenceStyle(occurrence: TimelineOccurrence) {
+    const eventDef = this.facade.eventDefs().find(definition => definition.id === occurrence.eventDefId);
+    const background = eventDef?.colorHex ?? this.defaultEventColor;
+    const isSelected = this.facade.selectionIds().includes(occurrence.id);
+
+    return {
+      backgroundColor: isSelected ? this.withOpacity(background, 0.8) : background,
+      color: getReadableTextColor(background),
+    };
+  }
+
   playheadLeftPx() {
     return this.timebase.currentTimeMs() * this.pxPerMs;
   }
@@ -191,6 +204,15 @@ export class TimelineComponent implements OnDestroy {
     });
     this.facade.setScroll(targetLeft, timeScrollEl.scrollTop);
     this.facade.setAutoFollow(true);
+  }
+
+  private withOpacity(hex: string, opacity: number) {
+    const value = hex.trim();
+    const normalized = /^#?[0-9a-fA-F]{6}$/.test(value) ? (value.startsWith('#') ? value : `#${value}`) : this.defaultEventColor;
+    const r = Number.parseInt(normalized.slice(1, 3), 16);
+    const g = Number.parseInt(normalized.slice(3, 5), 16);
+    const b = Number.parseInt(normalized.slice(5, 7), 16);
+    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
   }
 
   private setProgrammaticScroll(callback: () => void) {

--- a/src/app/core/services/timeline-facade.service.ts
+++ b/src/app/core/services/timeline-facade.service.ts
@@ -4,6 +4,7 @@ import { TimebaseService } from './timebase.service';
 import { VideoService } from './video.service';
 import { SequencerPanelService } from '../service/sequencer-panel.service';
 import { SequencerRuntimeEvent, SequencerRuntimeService } from '../service/sequencer-runtime.service';
+import { EventBtn } from '../../interfaces/sequencer-btn.interface';
 import {
   TIMELINE_BUFFER_WORK_DURATION_MS,
   TIMELINE_DEFAULT_POST_MS,
@@ -22,7 +23,9 @@ import {
   upsertDefinitions,
 } from '../../store/Timeline/timeline.actions';
 import {
+  selectTimelineAllOccurrencesSelected,
   selectTimelineAutoFollow,
+  selectTimelineCanUndoShiftAlign,
   selectTimelineEventDefs,
   selectTimelineOccurrences,
   selectTimelineScroll,
@@ -43,6 +46,8 @@ export class TimelineFacadeService {
   readonly selectionIds = this.store.selectSignal(selectTimelineSelectionIds);
   readonly uiScroll = this.store.selectSignal(selectTimelineScroll);
   readonly autoFollow = this.store.selectSignal(selectTimelineAutoFollow);
+  readonly canUndoShiftOrAlign = this.store.selectSignal(selectTimelineCanUndoShiftAlign);
+  readonly allOccurrencesSelected = this.store.selectSignal(selectTimelineAllOccurrencesSelected);
 
   readonly hasChronoOrVideo: Signal<boolean> = computed(
     () => this.timebase.mode() === 'video' || this.timebase.currentTimeMs() > 0,
@@ -81,6 +86,16 @@ export class TimelineFacadeService {
 
   setSelection(ids: string[]) {
     this.store.dispatch(setSelection({ ids }));
+  }
+
+
+  toggleAllSelections() {
+    if (this.allOccurrencesSelected()) {
+      this.setSelection([]);
+      return;
+    }
+
+    this.setSelection(this.occurrences().map(occurrence => occurrence.id));
   }
 
   toggleSelection(id: string, additive: boolean) {
@@ -236,11 +251,12 @@ export class TimelineFacadeService {
   private buildDefinitionsFromSequencer(): TimelineDefinitions {
     const btnList = this.sequencerPanelService.btnList();
     const eventDefs: TimelineDefinitions['eventDefs'] = btnList
-      .filter(btn => btn.type === 'event')
+      .filter((btn): btn is EventBtn => btn.type === 'event')
       .map((btn): TimelineEventDef => ({
         id: btn.id,
         sourceSequencerBtnId: btn.id,
         name: btn.name,
+        colorHex: btn.colorHex,
         timingMode: btn.eventProps.kind === 'indefinite' ? 'indefinite' : 'once',
         preMs: btn.eventProps.preMs || TIMELINE_DEFAULT_PRE_MS,
         postMs: btn.eventProps.postMs || TIMELINE_DEFAULT_POST_MS,

--- a/src/app/interfaces/sequencer-btn.interface.ts
+++ b/src/app/interfaces/sequencer-btn.interface.ts
@@ -14,6 +14,7 @@ export interface SequencerBtnBase {
 
 export interface EventBtn extends SequencerBtnBase {
   type: 'event';
+  colorHex?: string;
   eventProps: {
     kind: 'limited' | 'indefinite';
     preMs: number;

--- a/src/app/interfaces/timeline/timeline.interface.ts
+++ b/src/app/interfaces/timeline/timeline.interface.ts
@@ -14,6 +14,7 @@ export interface TimelineEventDef {
   id: string;
   sourceSequencerBtnId: string;
   name: string;
+  colorHex?: string;
   timingMode: TimelineTimingMode;
   preMs: number;
   postMs: number;

--- a/src/app/store/Timeline/timeline.selectors.ts
+++ b/src/app/store/Timeline/timeline.selectors.ts
@@ -11,3 +11,9 @@ export const selectTimelineUi = createSelector(selectTimelineState, state => sta
 export const selectTimelineSelectionIds = createSelector(selectTimelineUi, ui => ui.selectedOccurrenceIds);
 export const selectTimelineAutoFollow = createSelector(selectTimelineUi, ui => ui.autoFollow);
 export const selectTimelineScroll = createSelector(selectTimelineUi, ui => ({ scrollX: ui.scrollX, scrollY: ui.scrollY }));
+export const selectTimelineCanUndoShiftAlign = createSelector(selectTimelineState, state => state.lastShiftDeltaMs !== null);
+export const selectTimelineAllOccurrencesSelected = createSelector(
+  selectTimelineOccurrences,
+  selectTimelineSelectionIds,
+  (occurrences, selectionIds) => occurrences.length > 0 && selectionIds.length === occurrences.length,
+);

--- a/src/app/utils/color/color-contrast.utils.spec.ts
+++ b/src/app/utils/color/color-contrast.utils.spec.ts
@@ -1,0 +1,18 @@
+import { getReadableTextColor, isLightColor } from './color-contrast.utils';
+
+describe('color-contrast.utils', () => {
+  it('detects light colors using relative luminance', () => {
+    expect(isLightColor('#FFFFFF')).toBeTrue();
+    expect(isLightColor('#F2D06B')).toBeTrue();
+  });
+
+  it('detects dark colors and chooses readable light text', () => {
+    expect(isLightColor('#1F3D28')).toBeFalse();
+    expect(getReadableTextColor('#1F3D28')).toBe('#FAFAFA');
+  });
+
+  it('falls back safely on invalid values', () => {
+    expect(isLightColor('invalid')).toBeFalse();
+    expect(getReadableTextColor('invalid')).toBe('#FAFAFA');
+  });
+});

--- a/src/app/utils/color/color-contrast.utils.ts
+++ b/src/app/utils/color/color-contrast.utils.ts
@@ -1,0 +1,42 @@
+const HEX_COLOR_REGEX = /^#?[0-9a-fA-F]{6}$/;
+
+function normalizeHex(hex: string): string | null {
+  const value = hex.trim();
+  if (!HEX_COLOR_REGEX.test(value)) {
+    return null;
+  }
+  return value.startsWith('#') ? value.toUpperCase() : `#${value.toUpperCase()}`;
+}
+
+function srgbToLinear(channel: number): number {
+  const normalized = channel / 255;
+  if (normalized <= 0.03928) {
+    return normalized / 12.92;
+  }
+  return ((normalized + 0.055) / 1.055) ** 2.4;
+}
+
+function relativeLuminance(hex: string): number | null {
+  const normalizedHex = normalizeHex(hex);
+  if (!normalizedHex) {
+    return null;
+  }
+
+  const r = Number.parseInt(normalizedHex.slice(1, 3), 16);
+  const g = Number.parseInt(normalizedHex.slice(3, 5), 16);
+  const b = Number.parseInt(normalizedHex.slice(5, 7), 16);
+
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+export function isLightColor(hex: string): boolean {
+  const luminance = relativeLuminance(hex);
+  if (luminance === null) {
+    return false;
+  }
+  return luminance > 0.179;
+}
+
+export function getReadableTextColor(hex: string): '#FAFAFA' | '#0C0C0C' {
+  return isLightColor(hex) ? '#0C0C0C' : '#FAFAFA';
+}

--- a/src/theme/_global.class.scss
+++ b/src/theme/_global.class.scss
@@ -65,6 +65,10 @@
   color: var(--sequencer-label-text);
 }
 
+.seq-btn-event-card {
+  border-color: var(--sequencer-event-border) !important;
+}
+
 .seq-btn-event-active {
   opacity: 0.88;
 }

--- a/src/theme/_timeline.class.scss
+++ b/src/theme/_timeline.class.scss
@@ -12,6 +12,28 @@
   background-color: var(--timeline-playhead);
 }
 
+.timeline-occurrence {
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  padding-inline: 8px;
+}
+
+.timeline-occurrence-selected {
+  outline: 1px solid var(--interactive-active-border);
+  outline-offset: 1px;
+}
+
+.timeline-occurrence-label {
+  position: relative;
+  z-index: 1;
+  font-size: 11px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .timeline-resize-handle {
   position: absolute;
   top: 0;

--- a/src/theme/variables/_timeline.variables.scss
+++ b/src/theme/variables/_timeline.variables.scss
@@ -2,4 +2,5 @@
   --timeline-occurrence-bg: rgba(79, 70, 229, 0.22);
   --timeline-occurrence-border: rgba(129, 140, 248, 0.9);
   --timeline-playhead: rgba(248, 113, 113, 1);
+  --timeline-event-default-bg: #1f3d28;
 }


### PR DESCRIPTION
### Motivation
- Améliorer l’UX de la Timeline et du Séquenceur en supportant une couleur par event (source de vérité = séquenceur) et un texte automatiquement contrasté. 
- Rendre la sélection des occurrences plus visible sans toucher la logique fonctionnelle existante et centraliser l’Undo des décalages dans le footer à côté des contrôles de décalage.

### Description
- Ajout d’un champ optionnel `colorHex?: string` sur les définitions d’events séquenceur (`EventBtn`) et propagation vers les définitions timeline (`TimelineEventDef`) via la façade (`TimelineFacadeService`).  
- UI: ajout d’un `input type="color"` natif dans le dialog de création/édition d’Event et persistance de `colorHex` lors de `addEventBtn` / `updateBtn`.  
- Helpers couleur: nouvelle utilitaire `src/app/utils/color/color-contrast.utils.ts` implémentant `isLightColor(hex)` (luminance relative) et `getReadableTextColor(hex)` retournant `'#FAFAFA'` ou `'#0C0C0C'`, avec tests unitaires `color-contrast.utils.spec.ts`.  
- Rendu UI: le canvas du séquenceur applique `event.colorHex` en background et utilise `getReadableTextColor` pour la couleur du texte; la Timeline utilise `eventDef.colorHex` pour le fond des occurrences et applique le texte auto-contrasté.  
- Sélection Timeline: l’occurrence sélectionnée applique une opacité 0.8 sur le fond (via `rgba(...)`) tout en gardant le texte lisible et ajoute un outline thémé (`.timeline-occurrence-selected`) si nécessaire.  
- Footer Timeline: affichage `Sélection : N`, bouton toggle global `Tout sélectionner / Tout désélectionner` (opère sur toutes les occurrences), et bouton `Annuler décalage` (Undo des actions shift/align) déplacé dans le footer et désactivé quand rien à annuler; nouveaux selectors `selectTimelineCanUndoShiftAlign` et `selectTimelineAllOccurrencesSelected` et méthodes associées (`toggleAllSelections`) exposées par la façade.  
- Theming/SCSS: classes sémantiques ajoutées dans le thème (`src/theme/_timeline.class.scss`, `src/theme/variables/_timeline.variables.scss`, `src/theme/_global.class.scss`) sans utiliser de classes couleurs Tailwind dans `/analyse`.

### Testing
- Type-check: `npx tsc -p tsconfig.app.json --noEmit` — succeeded.  
- Unit test run (Karma) for the new helper: attempted `npm test -- --watch=false --include='src/app/utils/color/color-contrast.utils.spec.ts'` but test runner could not start a browser in this environment (`No binary for Chrome browser on your platform`), so the spec exists and is syntactically correct but could not be executed here.  
- Build: `npm run build` attempted but failed in this environment due to Google Fonts inlining returning HTTP 403 (environment/network limitation), unrelated to the changes.  

Notes: changes are UI/UX-only (no business logic modified), color choice is free (native color-picker) and text-contrast computation uses relative luminance per WCAG-style guidance; no Tailwind color utilities were added under `/analyse`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3f1d94fa08326b6e8ba4cf22569ed)