### PR TITLE
Add zoom controls and services; integrate zoom into timeline and sequencer canvases

### DIFF
--- a/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.html
+++ b/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.html
@@ -1,57 +1,74 @@
-<div
-  class="bg-layer-1 bg-canvas-grid hide-scrollbar border-layer relative h-full min-h-0 overflow-auto rounded-md border"
-  data-pan-surface="true"
-  (mousedown)="onViewportMouseDown($event)"
->
-  <div class="relative" data-pan-surface="true" [ngStyle]="contentStyle()">
-    @for (btn of btnList; track btn.id) {
-      <div
-        role="button"
-        tabindex="0"
-        class="absolute flex select-none flex-col items-center justify-center gap-1 overflow-hidden rounded-md border p-2 text-center"
-        [class.seq-btn-event-card]="btn.type === 'event'"
-        [class.seq-btn-label]="btn.type === 'label'"
-        [class.seq-btn-event-active]="btn.type === 'event' && isActive(btn.id)"
-        [ngStyle]="btnStyle(btn)"
-        [class.is-pressed]="lastTriggeredBtnId === btn.id"
-        (mousedown)="onBtnMouseDown($event, btn)"
-        (click)="onBtnClick($event, btn)"
-      >
-        @if (editMode) {
-          <div class="absolute left-1 top-1 z-20">
-            <button
-              type="button"
-              class="flex h-4 w-4 min-h-4 min-w-4 items-center justify-center"
-              (click)="onEditIconClick($event, btn)"
-            >
-              <mat-icon class="h-3 w-3 text-[12px]">edit</mat-icon>
-            </button>
+<div #canvasContainer class="relative h-full min-h-0">
+  <div
+    class="bg-layer-1 bg-canvas-grid hide-scrollbar border-layer relative h-full min-h-0 overflow-auto rounded-md border"
+    data-pan-surface="true"
+    (mousedown)="onViewportMouseDown($event)"
+  >
+    <div class="relative" data-pan-surface="true" [ngStyle]="zoomedCanvasStyle()">
+      <div class="absolute left-0 top-0" data-pan-surface="true" [ngStyle]="contentStyle()" [style.transform]="'scale(' + zoom() + ')'" style="transform-origin: top left;">
+        @for (btn of btnList; track btn.id) {
+          <div
+            role="button"
+            tabindex="0"
+            class="absolute flex select-none flex-col items-center justify-center gap-1 overflow-hidden rounded-md border p-2 text-center"
+            [class.seq-btn-event-card]="btn.type === 'event'"
+            [class.seq-btn-label]="btn.type === 'label'"
+            [class.seq-btn-event-active]="btn.type === 'event' && isActive(btn.id)"
+            [ngStyle]="btnStyle(btn)"
+            [class.is-pressed]="lastTriggeredBtnId === btn.id"
+            (mousedown)="onBtnMouseDown($event, btn)"
+            (click)="onBtnClick($event, btn)"
+          >
+            @if (editMode) {
+              <div class="absolute left-1 top-1 z-20">
+                <button
+                  type="button"
+                  class="flex h-4 w-4 min-h-4 min-w-4 items-center justify-center"
+                  (click)="onEditIconClick($event, btn)"
+                >
+                  <mat-icon class="h-3 w-3 text-[12px]">edit</mat-icon>
+                </button>
+              </div>
+              <div class="absolute right-1 top-1 z-20">
+                <button
+                  type="button"
+                  class="flex h-4 w-4 min-h-4 min-w-4 items-center justify-center"
+                  (click)="onDeleteIconClick($event, btn)"
+                >
+                  <mat-icon class="h-3 w-3 text-[12px]">delete</mat-icon>
+                </button>
+              </div>
+            }
+
+            <div class="min-w-0 max-w-full px-1">
+              <div class="text-[10px] font-medium">{{ btn.id }}</div>
+              <div class="truncate text-xs font-semibold">{{ btn.name }}</div>
+            </div>
+
+            <div class="w-full text-[10px]">{{ formatHotkey(btn.hotkeyNormalized) }}</div>
+
+            @if (editMode) {
+              <span
+                class="border-layer bg-layer-0 absolute bottom-0 right-0 h-3.5 w-3.5 cursor-se-resize rounded-tl border-l border-t"
+                (mousedown)="onResizeHandleMouseDown($event, btn)"
+              ></span>
+            }
           </div>
-          <div class="absolute right-1 top-1 z-20">
-            <button
-              type="button"
-              class="flex h-4 w-4 min-h-4 min-w-4 items-center justify-center"
-              (click)="onDeleteIconClick($event, btn)"
-            >
-              <mat-icon class="h-3 w-3 text-[12px]">delete</mat-icon>
-            </button>
-          </div>
-        }
-
-        <div class="min-w-0 max-w-full px-1">
-          <div class="text-[10px] font-medium">{{ btn.id }}</div>
-          <div class="truncate text-xs font-semibold">{{ btn.name }}</div>
-        </div>
-
-        <div class="w-full text-[10px]">{{ formatHotkey(btn.hotkeyNormalized) }}</div>
-
-        @if (editMode) {
-          <span
-            class="border-layer bg-layer-0 absolute bottom-0 right-0 h-3.5 w-3.5 cursor-se-resize rounded-tl border-l border-t"
-            (mousedown)="onResizeHandleMouseDown($event, btn)"
-          ></span>
         }
       </div>
-    }
+    </div>
   </div>
+
+  @if (showZoom()) {
+    <div class="absolute bottom-2 left-1/2 z-50 -translate-x-1/2">
+      <app-zoom-controls
+        [value]="sequencerZoom.zoom()"
+        [min]="sequencerZoom.min"
+        [max]="sequencerZoom.max"
+        [step]="sequencerZoom.step"
+        [ariaLabel]="'Zoom sequencer'"
+        (valueChange)="sequencerZoom.setZoom($event)"
+      ></app-zoom-controls>
+    </div>
+  }
 </div>

--- a/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.ts
+++ b/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.ts
@@ -1,11 +1,15 @@
 import { CommonModule } from '@angular/common';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   EventEmitter,
   HostListener,
   Input,
+  OnDestroy,
   Output,
+  ViewChild,
   computed,
   inject,
   signal,
@@ -13,6 +17,7 @@ import {
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { SequencerPanelService } from '../../../../core/service/sequencer-panel.service';
+import { SequencerZoomService } from '../../../../core/services/sequencer-zoom.service';
 import { SequencerBtn } from '../../../../interfaces/sequencer-btn.interface';
 import {
   contentMinHeightPx,
@@ -24,6 +29,7 @@ import {
 } from '../../../../utils/sequencer/sequencer-canvas-defaults.util';
 import { formatNormalizedHotkey } from '../../../../utils/sequencer/sequencer-hotkey-options.util';
 import { getReadableTextColor } from '../../../../utils/color/color-contrast.utils';
+import { ZoomControlsComponent } from '../../../shared/zoom-controls/zoom-controls.component';
 
 @Component({
   selector: 'app-sequencer-canvas',
@@ -31,11 +37,19 @@ import { getReadableTextColor } from '../../../../utils/color/color-contrast.uti
   templateUrl: './sequencer-canvas.component.html',
   styleUrl: './sequencer-canvas.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatButtonModule, MatIconModule],
+  imports: [CommonModule, MatButtonModule, MatIconModule, ZoomControlsComponent],
 })
-export class SequencerCanvasComponent {
+export class SequencerCanvasComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('canvasContainer', { static: false }) canvasContainerRef?: ElementRef<HTMLDivElement>;
+
+  private readonly minZoomContainerPx = 250;
   private readonly defaultEventColor = '#1F3D28';
   private readonly panelService = inject(SequencerPanelService);
+  readonly sequencerZoom = inject(SequencerZoomService);
+  readonly containerWidthPx = signal(0);
+  readonly showZoom = computed(() => this.containerWidthPx() >= this.minZoomContainerPx);
+
+  private resizeObserver?: ResizeObserver;
 
   @Input({ required: true }) btnList: SequencerBtn[] = [];
   @Input({ required: true }) editMode = false;
@@ -63,11 +77,23 @@ export class SequencerCanvasComponent {
     };
   });
 
+  readonly zoom = this.sequencerZoom.zoom;
+
   readonly contentBounds = computed(() => {
     const style = this.contentStyle();
     return {
       width: Number.parseInt(style.width, 10) || contentMinWidthPx,
       height: Number.parseInt(style.height, 10) || contentMinHeightPx,
+    };
+  });
+
+
+  readonly zoomedCanvasStyle = computed(() => {
+    const bounds = this.contentBounds();
+    const zoom = this.zoom();
+    return {
+      width: `${bounds.width * zoom}px`,
+      height: `${bounds.height * zoom}px`,
     };
   });
 
@@ -95,6 +121,28 @@ export class SequencerCanvasComponent {
     originW: number;
     originH: number;
   } | null>(null);
+
+  ngAfterViewInit() {
+    const canvasContainer = this.canvasContainerRef?.nativeElement;
+    if (!canvasContainer) {
+      return;
+    }
+
+    this.containerWidthPx.set(canvasContainer.clientWidth);
+    if (typeof window === 'undefined' || !('ResizeObserver' in window)) {
+      return;
+    }
+
+    this.resizeObserver = new ResizeObserver(() => {
+      this.containerWidthPx.set(canvasContainer.clientWidth);
+    });
+    this.resizeObserver.observe(canvasContainer);
+  }
+
+  ngOnDestroy() {
+    this.resizeObserver?.disconnect();
+    this.resizeObserver = undefined;
+  }
 
   ensureBtnLayout(btn: SequencerBtn) {
     return this.panelService.ensureLayout(btn);
@@ -163,9 +211,10 @@ export class SequencerCanvasComponent {
     if (drag) {
       const deltaX = event.clientX - drag.startX;
       const deltaY = event.clientY - drag.startY;
+      const zoom = this.zoom();
       const next = this.clampLayoutWithinCanvas(drag.btnId, {
-        x: drag.originX + deltaX,
-        y: drag.originY + deltaY,
+        x: drag.originX + deltaX / zoom,
+        y: drag.originY + deltaY / zoom,
       });
       this.panelService.updateLayout(drag.btnId, next);
     }
@@ -174,9 +223,10 @@ export class SequencerCanvasComponent {
     if (resize) {
       const deltaX = event.clientX - resize.startX;
       const deltaY = event.clientY - resize.startY;
+      const zoom = this.zoom();
       const next = this.clampLayoutWithinCanvas(resize.btnId, {
-        w: Math.max(minButtonWidthPx, resize.originW + deltaX),
-        h: Math.max(minButtonHeightPx, resize.originH + deltaY),
+        w: Math.max(minButtonWidthPx, resize.originW + deltaX / zoom),
+        h: Math.max(minButtonHeightPx, resize.originH + deltaY / zoom),
       });
       this.panelService.updateLayout(resize.btnId, next);
     }

--- a/src/app/components/analyse/timeline/timeline.component.html
+++ b/src/app/components/analyse/timeline/timeline.component.html
@@ -31,6 +31,16 @@
     <button class="btn-secondary" (click)="recenter()">Recentrer</button>
     <button class="btn-secondary" (click)="facade.playSelection()">Play selection</button>
 
+    <app-zoom-controls
+      class="mx-2"
+      [value]="timelineZoom.uiZoom()"
+      [min]="timelineZoom.min"
+      [max]="timelineZoom.max"
+      [step]="timelineZoom.step"
+      [ariaLabel]="'Zoom timeline'"
+      (valueChange)="timelineZoom.setUiZoom($event)"
+    ></app-zoom-controls>
+
     <button
       class="btn-secondary ml-auto flex items-center justify-center"
       type="button"
@@ -79,7 +89,7 @@
               (mousedown)="onRulerPointerDown($event)"
             >
               @for (tick of rulerTicks(); track tick) {
-                <span class="border-subtle absolute top-0 h-full border-l text-[10px] text-muted" [style.left.px]="tick * 80">{{ tick }}s</span>
+                <span class="border-subtle absolute top-0 h-full border-l text-[10px] text-muted" [style.left.px]="tick * 80">{{ formatTime(tick * tickMs()) }}</span>
               }
               <span class="bg-timeline-playhead absolute top-0 h-full w-0.5" [style.left.px]="playheadLeftPx()"></span>
             </div>

--- a/src/app/components/analyse/timeline/timeline.component.ts
+++ b/src/app/components/analyse/timeline/timeline.component.ts
@@ -1,5 +1,16 @@
 import { CommonModule } from '@angular/common';
-import { Component, ElementRef, HostListener, OnDestroy, ViewChild, computed, effect, inject, signal } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  HostListener,
+  OnDestroy,
+  ViewChild,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import {
@@ -14,15 +25,17 @@ import { TimelineOccurrence } from '../../../interfaces/timeline/timeline.interf
 import { TimelineLabelsDialogComponent } from './timeline-labels-dialog.component';
 import { getReadableTextColor } from '../../../utils/color/color-contrast.utils';
 import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
+import { TimelineZoomService } from '../../../core/services/timeline-zoom.service';
+import { ZoomControlsComponent } from '../../shared/zoom-controls/zoom-controls.component';
 
 @Component({
   selector: 'app-timeline',
   standalone: true,
-  imports: [CommonModule, MatIconModule],
+  imports: [CommonModule, MatIconModule, ZoomControlsComponent],
   templateUrl: './timeline.component.html',
   styleUrl: './timeline.component.scss',
 })
-export class TimelineComponent implements OnDestroy {
+export class TimelineComponent implements OnDestroy, AfterViewInit {
   @ViewChild('timeScrollEl', { static: false }) timeScrollElRef?: ElementRef<HTMLDivElement>;
   @ViewChild('timelineRoot', { static: false }) timelineRootRef?: ElementRef<HTMLDivElement>;
 
@@ -30,24 +43,87 @@ export class TimelineComponent implements OnDestroy {
   readonly timebase = inject(TimebaseService);
   private readonly dialog = inject(MatDialog);
   private readonly confirmDialogService = inject(ConfirmDialogService);
+  readonly timelineZoom = inject(TimelineZoomService);
 
   readonly rowHeightPx = TIMELINE_ROW_HEIGHT_PX;
   readonly rulerHeightPx = 36;
   readonly leftColumnWidthPx = 220;
-  readonly pxPerMs = TIMELINE_PIXELS_PER_SECOND / 1000;
+  readonly basePxPerMs = TIMELINE_PIXELS_PER_SECOND / 1000;
 
   readonly scrollTopPx = signal(0);
   readonly timelineHasFocus = signal(false);
   readonly isEditingTimelineName = signal(false);
   readonly timelineNameDraft = signal('');
+  readonly containerWidthPx = signal(0);
 
   private readonly isProgrammaticScrollSignal = signal(false);
   private programmaticScrollTimeoutId?: number;
+  private timelineResizeObserver?: ResizeObserver;
   private readonly defaultEventColor = '#1F3D28';
 
-  readonly contentWidthPx = computed(() => Math.max(1200, Math.ceil(this.facade.workDurationMs() * this.pxPerMs)));
+  readonly displayDurationMs = computed(() => this.facade.workDurationMs());
+
+  readonly fitTargetDurationMs = computed(() => {
+    if (this.timebase.mode() !== 'clock') {
+      return this.displayDurationMs();
+    }
+
+    const occurrences = this.facade.occurrences();
+    if (occurrences.length === 0) {
+      return this.displayDurationMs();
+    }
+
+    const eventDefsById = new Map(this.facade.eventDefs().map(eventDef => [eventDef.id, eventDef]));
+    const hasOpenOccurrence = occurrences.some(occurrence => occurrence.isOpen);
+    const currentTimeMs = hasOpenOccurrence ? this.timebase.currentTimeMs() : 0;
+
+    const maxEndMs = occurrences.reduce((maxValue, occurrence) => {
+      if (occurrence.isOpen) {
+        const eventDef = eventDefsById.get(occurrence.eventDefId);
+        const endCandidate = currentTimeMs + (eventDef?.postMs ?? 1000);
+        return Math.max(maxValue, endCandidate);
+      }
+      return Math.max(maxValue, occurrence.endMs);
+    }, 0);
+
+    return maxEndMs > 0 ? maxEndMs : this.displayDurationMs();
+  });
+
+  readonly fitZoom = computed(() => {
+    const width = this.containerWidthPx();
+    const durationMs = this.fitTargetDurationMs();
+
+    if (width <= 0 || durationMs <= 0) {
+      return 1;
+    }
+
+    const rawFit = width / (durationMs * this.basePxPerMs);
+    return this.clamp(rawFit, 0.01, 1);
+  });
+
+  readonly actualZoom = computed(() => {
+    const ui = this.timelineZoom.uiZoom();
+    const fit = this.fitZoom();
+
+    if (fit >= this.timelineZoom.min) {
+      return ui;
+    }
+
+    const t = this.clamp((ui - this.timelineZoom.min) / (this.timelineZoom.max - this.timelineZoom.min), 0, 1);
+    return fit + t * (1 - fit);
+  });
+
+  readonly pxPerMs = computed(() => this.basePxPerMs * this.actualZoom());
+
+  readonly contentWidthPx = computed(() => {
+    const minWidth = Math.max(1, this.containerWidthPx());
+    const naturalWidth = Math.ceil(this.displayDurationMs() * this.pxPerMs());
+    return Math.max(minWidth, naturalWidth);
+  });
+
   readonly contentHeightPx = computed(() => this.rulerHeightPx + this.facade.eventDefs().length * this.rowHeightPx);
   readonly rulerTicks = computed(() => Array.from({ length: Math.ceil(this.contentWidthPx() / 80) }, (_, index) => index));
+  readonly tickMs = computed(() => 80 / this.pxPerMs());
 
   readonly selectedOccurrences = computed(() => {
     const selectedIds = new Set(this.facade.selectionIds());
@@ -82,7 +158,7 @@ export class TimelineComponent implements OnDestroy {
         return;
       }
 
-      const playheadX = this.timebase.currentTimeMs() * this.pxPerMs;
+      const playheadX = this.timebase.currentTimeMs() * this.pxPerMs();
       const leftComfort = timeScrollEl.scrollLeft + timeScrollEl.clientWidth * TIMELINE_AUTO_FOLLOW_COMFORT_ZONE[0];
       const rightComfort = timeScrollEl.scrollLeft + timeScrollEl.clientWidth * TIMELINE_AUTO_FOLLOW_COMFORT_ZONE[1];
       if (playheadX >= leftComfort && playheadX <= rightComfort) {
@@ -97,11 +173,32 @@ export class TimelineComponent implements OnDestroy {
     });
   }
 
+  ngAfterViewInit() {
+    const timeScrollEl = this.timeScrollElRef?.nativeElement;
+    if (!timeScrollEl) {
+      return;
+    }
+
+    this.containerWidthPx.set(timeScrollEl.clientWidth);
+
+    if (typeof window === 'undefined' || !('ResizeObserver' in window)) {
+      return;
+    }
+
+    this.timelineResizeObserver = new ResizeObserver(() => {
+      this.containerWidthPx.set(timeScrollEl.clientWidth);
+    });
+    this.timelineResizeObserver.observe(timeScrollEl);
+  }
+
   ngOnDestroy() {
     if (this.programmaticScrollTimeoutId !== undefined) {
       window.clearTimeout(this.programmaticScrollTimeoutId);
       this.programmaticScrollTimeoutId = undefined;
     }
+
+    this.timelineResizeObserver?.disconnect();
+    this.timelineResizeObserver = undefined;
   }
 
   @HostListener('document:mousedown', ['$event'])
@@ -155,7 +252,6 @@ export class TimelineComponent implements OnDestroy {
       return;
     }
 
-    // Backspace = Delete sur clavier Mac.
     event.preventDefault();
     await this.deleteSelection();
   }
@@ -202,7 +298,6 @@ export class TimelineComponent implements OnDestroy {
     return `Supprimer la sélection (${this.selectedCount()})`;
   }
 
-
   startTimelineNameEdit() {
     this.timelineNameDraft.set(this.facade.timelineName());
     this.isEditingTimelineName.set(true);
@@ -240,7 +335,7 @@ export class TimelineComponent implements OnDestroy {
       const rulerRect = timeScrollEl.getBoundingClientRect();
       const xWithinViewport = Math.max(0, pointerEvent.clientX - rulerRect.left);
       const absoluteX = xWithinViewport + timeScrollEl.scrollLeft;
-      const targetMs = Math.max(0, absoluteX / this.pxPerMs);
+      const targetMs = Math.max(0, absoluteX / this.pxPerMs());
       this.timebase.seekTo(targetMs);
     };
 
@@ -276,7 +371,7 @@ export class TimelineComponent implements OnDestroy {
     const initialEnd = occurrence.endMs;
 
     const move = (moveEvent: MouseEvent) => {
-      const deltaMs = (moveEvent.clientX - startX) / this.pxPerMs;
+      const deltaMs = (moveEvent.clientX - startX) / this.pxPerMs();
       if (edge === 'start') {
         this.facade.updateOccurrenceTiming(occurrence.id, initialStart + deltaMs, initialEnd);
       } else {
@@ -334,11 +429,11 @@ export class TimelineComponent implements OnDestroy {
   occurrenceWidthPx(occurrence: TimelineOccurrence) {
     const eventDef = this.facade.eventDefs().find(definition => definition.id === occurrence.eventDefId);
     const endMs = occurrence.isOpen ? this.timebase.currentTimeMs() + (eventDef?.postMs ?? 1000) : occurrence.endMs;
-    return Math.max(8, (endMs - occurrence.startMs) * this.pxPerMs);
+    return Math.max(8, (endMs - occurrence.startMs) * this.pxPerMs());
   }
 
   occurrenceLeftPx(occurrence: TimelineOccurrence) {
-    return occurrence.startMs * this.pxPerMs;
+    return occurrence.startMs * this.pxPerMs();
   }
 
   occurrenceLabelSummary(occurrence: TimelineOccurrence) {
@@ -348,6 +443,17 @@ export class TimelineComponent implements OnDestroy {
       hiddenCount: Math.max(0, labelNames.length - 2),
       tooltip: labelNames.join(', '),
     };
+  }
+
+  formatTime(valueMs: number) {
+    const totalSeconds = Math.max(0, Math.floor(valueMs / 1000));
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds
+      .toString()
+      .padStart(2, '0')}`;
   }
 
   private occurrenceLabelNames(occurrence: TimelineOccurrence) {
@@ -367,7 +473,7 @@ export class TimelineComponent implements OnDestroy {
   }
 
   playheadLeftPx() {
-    return this.timebase.currentTimeMs() * this.pxPerMs;
+    return this.timebase.currentTimeMs() * this.pxPerMs();
   }
 
   recenter() {
@@ -401,6 +507,10 @@ export class TimelineComponent implements OnDestroy {
     const g = Number.parseInt(normalized.slice(3, 5), 16);
     const b = Number.parseInt(normalized.slice(5, 7), 16);
     return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+  }
+
+  private clamp(value: number, min: number, max: number) {
+    return Math.min(max, Math.max(min, value));
   }
 
   private setProgrammaticScroll(callback: () => void) {

--- a/src/app/components/shared/zoom-controls/zoom-controls.component.html
+++ b/src/app/components/shared/zoom-controls/zoom-controls.component.html
@@ -1,0 +1,13 @@
+<div class="zoom-controls zoom-controls--compact bg-layer-1 border-layer-2 text-main inline-flex items-center gap-2 rounded-xl border px-2" [attr.aria-label]="ariaLabel">
+  <button type="button" mat-icon-button [disabled]="disabled" [attr.aria-label]="'Diminuer le zoom'" (click)="zoomOut()">
+    <mat-icon>remove</mat-icon>
+  </button>
+
+  <mat-slider class="w-24" [min]="min" [max]="max" [step]="step" [disabled]="disabled" [discrete]="false">
+    <input matSliderThumb [value]="value" (input)="onThumbInput($event)" [attr.aria-label]="ariaLabel" />
+  </mat-slider>
+
+  <button type="button" mat-icon-button [disabled]="disabled" [attr.aria-label]="'Augmenter le zoom'" (click)="zoomIn()">
+    <mat-icon>add</mat-icon>
+  </button>
+</div>

--- a/src/app/components/shared/zoom-controls/zoom-controls.component.spec.ts
+++ b/src/app/components/shared/zoom-controls/zoom-controls.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ZoomControlsComponent } from './zoom-controls.component';
+
+describe('ZoomControlsComponent', () => {
+  let component: ZoomControlsComponent;
+  let fixture: ComponentFixture<ZoomControlsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ZoomControlsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ZoomControlsComponent);
+    component = fixture.componentInstance;
+    component.min = 0.25;
+    component.max = 1;
+    component.step = 0.05;
+    component.value = 1;
+    fixture.detectChanges();
+  });
+
+  it('maps slider value directly', () => {
+    const emitSpy = spyOn(component.valueChange, 'emit');
+
+    component.onThumbInput({ target: { value: '0.7' } } as unknown as Event);
+
+    expect(emitSpy).toHaveBeenCalledWith(0.7);
+  });
+
+  it('clamps minus and plus actions to min and max', () => {
+    const emitSpy = spyOn(component.valueChange, 'emit');
+
+    component.value = component.min;
+    component.zoomOut();
+    component.value = component.max;
+    component.zoomIn();
+
+    expect(emitSpy).toHaveBeenCalledWith(component.min);
+    expect(emitSpy).toHaveBeenCalledWith(component.max);
+  });
+
+  it('emits on slider input changes', () => {
+    const emitSpy = spyOn(component.valueChange, 'emit');
+
+    component.onThumbInput({ target: { value: '0.95' } } as unknown as Event);
+
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith(0.95);
+  });
+});

--- a/src/app/components/shared/zoom-controls/zoom-controls.component.ts
+++ b/src/app/components/shared/zoom-controls/zoom-controls.component.ts
@@ -1,0 +1,47 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSliderModule } from '@angular/material/slider';
+
+@Component({
+  selector: 'app-zoom-controls',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatIconModule, MatSliderModule],
+  templateUrl: './zoom-controls.component.html',
+})
+export class ZoomControlsComponent {
+  @Input({ required: true }) value = 1;
+  @Input({ required: true }) min = 0.25;
+  @Input({ required: true }) max = 1;
+  @Input({ required: true }) step = 0.05;
+  @Input() disabled = false;
+  @Input() ariaLabel = 'Zoom controls';
+  @Output() valueChange = new EventEmitter<number>();
+
+  zoomOut() {
+    this.emitClamped(this.value - this.step);
+  }
+
+  zoomIn() {
+    this.emitClamped(this.value + this.step);
+  }
+
+  onThumbInput(event: Event) {
+    const sliderInput = event.target as HTMLInputElement | null;
+    if (!sliderInput) {
+      return;
+    }
+
+    this.emitClamped(Number.isFinite(sliderInput.valueAsNumber) ? sliderInput.valueAsNumber : Number(sliderInput.value));
+  }
+
+
+  private emitClamped(nextValue: number) {
+    this.valueChange.emit(this.clamp(nextValue));
+  }
+
+  private clamp(value: number) {
+    return Math.min(this.max, Math.max(this.min, value));
+  }
+}

--- a/src/app/core/services/hotkeys.service.ts
+++ b/src/app/core/services/hotkeys.service.ts
@@ -366,10 +366,20 @@ export class HotkeysService {
     if (!(target instanceof HTMLElement)) {
       return false;
     }
+
     const tagName = target.tagName.toLowerCase();
-    if (tagName === 'input' || tagName === 'textarea' || tagName === 'select') {
+    if (tagName === 'textarea' || tagName === 'select') {
       return true;
     }
+
+    if (tagName === 'input') {
+      const inputType = (target as HTMLInputElement).type.toLowerCase();
+      if (inputType === 'range' || inputType === 'checkbox' || inputType === 'radio' || inputType === 'button') {
+        return false;
+      }
+      return true;
+    }
+
     return target.isContentEditable;
   }
 

--- a/src/app/core/services/sequencer-zoom.service.ts
+++ b/src/app/core/services/sequencer-zoom.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SequencerZoomService {
+  readonly min = 0.25;
+  readonly max = 1;
+  readonly step = 0.05;
+  readonly default = 1;
+
+  private readonly _zoom = signal(this.default);
+  readonly zoom = this._zoom.asReadonly();
+
+  setZoom(value: number) {
+    this._zoom.set(this.clamp(value));
+  }
+
+  zoomIn() {
+    this.setZoom(this.zoom() + this.step);
+  }
+
+  zoomOut() {
+    this.setZoom(this.zoom() - this.step);
+  }
+
+  private clamp(value: number) {
+    return Math.min(this.max, Math.max(this.min, value));
+  }
+}

--- a/src/app/core/services/timeline-zoom.service.ts
+++ b/src/app/core/services/timeline-zoom.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, signal } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class TimelineZoomService {
+  readonly min = 0.05;
+  readonly max = 1;
+  readonly step = 0.05;
+  readonly default = 1;
+
+  private readonly _uiZoom = signal(this.default);
+  readonly uiZoom = this._uiZoom.asReadonly();
+
+  setUiZoom(value: number) {
+    this._uiZoom.set(this.clamp(value));
+  }
+
+  zoomIn() {
+    this.setUiZoom(this.uiZoom() + this.step);
+  }
+
+  zoomOut() {
+    this.setUiZoom(this.uiZoom() - this.step);
+  }
+
+  private clamp(value: number) {
+    return Math.min(this.max, Math.max(this.min, value));
+  }
+}

--- a/src/theme/override/_material-override.scss
+++ b/src/theme/override/_material-override.scss
@@ -86,3 +86,33 @@
     @apply mt-2 mb-4;
   }
 }
+
+.zoom-controls--compact {
+  border-radius: 12px;
+
+  .mat-mdc-icon-button {
+    width: 32px;
+    height: 32px;
+    padding: 0;
+  }
+
+  .mat-mdc-icon-button .mat-icon {
+    font-size: 18px;
+    width: 18px !important;
+    height: 18px !important;
+    line-height: 18px;
+  }
+
+  .mat-mdc-slider {
+    display: flex;
+    align-items: center;
+    min-width: 5rem;
+    width: 5rem;
+    flex: 0 0 5rem;
+    height: 28px;
+  }
+
+  .mat-mdc-slider .mdc-slider {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide user-facing zoom controls for the timeline and sequencer canvases to allow scalable views and better navigation.  
- Support fit-to-view behavior for the timeline while preserving a user-controlled UI zoom level.  
- Apply visual scaling to the sequencer canvas and ensure interactions (drag/resize) remain correct under zoom.  
- Expose a compact, reusable zoom control UI to be shared across components.

### Description
- Added a standalone `ZoomControlsComponent` (`src/app/components/shared/zoom-controls/*`) with template, logic, and a unit spec, and added compact styling in the Material overrides (`_material-override.scss`).
- Introduced `TimelineZoomService` and `SequencerZoomService` to manage zoom state and bounds for each area and wired them into the respective components.  
- Updated `TimelineComponent` to embed the zoom controls, calculate `fitZoom` and `actualZoom`, switch to a computed `pxPerMs()` scale, adjust content sizing, format ruler ticks with `formatTime`, and observe container size via `ResizeObserver` for responsive zoom behavior.  
- Updated `SequencerCanvasComponent` to render a scaled canvas via CSS `transform: scale(...)`, show zoom controls conditionally, use the sequencer zoom value in layout math, and divide drag/resize deltas by the current zoom so interactions remain accurate.

### Testing
- Added unit tests `zoom-controls.component.spec.ts` for `ZoomControlsComponent` and ran the component tests, which passed.  
- No other automated test failures were observed while validating the zoom component and integrating it into timeline and sequencer code.  
- Manual verification of layout scaling and interaction behavior was used alongside the unit test to ensure drag/resize math and ruler formatting behave under zoom.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5ae410d64832689a8e4d243968b45)