### PR TITLE
ci: align GHCR publish to prod branch and stable tags

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -3,7 +3,7 @@ name: Publish image
 on:
   push:
     branches:
-      - master
+      - prod
 
 concurrency:
   group: publish-image-${{ github.ref }}
@@ -20,6 +20,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Resolve image coordinates
+        id: image
+        run: |
+          OWNER_LOWER="${GITHUB_REPOSITORY_OWNER,,}"
+          IMAGE_NAME="ghcr.io/${OWNER_LOWER}/front-service"
+          echo "owner_lower=${OWNER_LOWER}" >> "$GITHUB_OUTPUT"
+          echo "name=${IMAGE_NAME}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -34,18 +42,16 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ${{ steps.image.outputs.name }}
           tags: |
-            type=raw,value=master
-            type=sha,format=short,prefix=sha-
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=prod
+            type=raw,value=sha-${{ github.sha }}
           labels: |
             org.opencontainers.image.title=front-service
             org.opencontainers.image.description=Frontend Angular SSR runtime image
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -53,3 +59,16 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Publish workflow summary
+        run: |
+          {
+            echo "## GHCR publication"
+            echo
+            echo "- Image: \`${{ steps.image.outputs.name }}\`"
+            echo "- Tag prod: \`${{ steps.image.outputs.name }}:prod\`"
+            echo "- Tag sha: \`${{ steps.image.outputs.name }}:sha-${{ github.sha }}\`"
+            echo "- Digest final: \`${{ steps.build.outputs.digest }}\`"
+            echo
+            echo "> Infra: privilégier un déploiement verrouillé sur le digest GHCR."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/contract/deployment/README.md
+++ b/contract/deployment/README.md
@@ -6,8 +6,9 @@ Ce dossier est la source de vérité à copier/consommer depuis le futur repo `i
 L'image `front` embarque le runtime **Angular SSR (Node/Express)**. Elle sert le HTML rendu côté serveur (SEO), les assets statiques Angular et une route de healthcheck.
 
 ## Image GHCR attendue
-- `ghcr.io/<owner>/<repo-front>:master`
-- Exemple pour ce repo : `ghcr.io/<org>/front-service:master`
+- `ghcr.io/<owner_lower>/front-service:prod`
+- `ghcr.io/<owner_lower>/front-service:sha-<full_sha>`
+- Image GHCR privée (consommée par le repo `infra` via droits de lecture GHCR).
 
 Voir aussi `ghcr-tags.md`.
 
@@ -20,7 +21,7 @@ Voir aussi `ghcr-tags.md`.
 ```bash
 docker run --rm -p 4000:4000 \
   -e AUTH_API_PREFIX=http://localhost:3000 \
-  ghcr.io/<owner>/<repo-front>:master
+  ghcr.io/<owner_lower>/front-service:prod
 ```
 
 ## Port exposé

--- a/contract/deployment/compose.service.yaml
+++ b/contract/deployment/compose.service.yaml
@@ -1,6 +1,6 @@
 services:
   front:
-    image: ghcr.io/<owner>/<repo-front>:master
+    image: ghcr.io/<owner_lower>/front-service:prod
     container_name: front
     restart: unless-stopped
     ports:

--- a/contract/deployment/ghcr-tags.md
+++ b/contract/deployment/ghcr-tags.md
@@ -1,13 +1,21 @@
 # GHCR tag policy
 
-Publication uniquement via `publish-image.yml`, déclenché sur `push` vers `master`.
+Publication uniquement via `publish-image.yml`, déclenché sur `push` vers `prod`.
+
+## Image publiée
+- `ghcr.io/<owner_lower>/front-service` (image privée GHCR)
+- Exemple : `ghcr.io/<org_lower>/front-service`
 
 ## Tags publiés
-- `master`: tag stable de la branche `master`.
-- `sha-<shortsha>`: tag immuable pour chaque commit publié.
-- tags Git (`refs/tags/*`): publiés si le workflow est adapté ultérieurement à des triggers tags.
-- SemVer (`x.y.z`, `x.y`) : générés quand des tags SemVer Git existent.
+- `prod`: tag stable de la branche `prod`.
+- `sha-<full_sha>`: tag immuable pour chaque commit publié (SHA Git complet).
 
 ## Contraintes
 - **Jamais de publication sur Pull Request.**
-- **Jamais de publication sur une branche autre que `master`.**
+- **Jamais de publication sur une branche autre que `prod`.**
+- **Aucun tag `latest`, `master` ou `main`.**
+
+## Repérer la bonne image rapidement
+- Dans GHCR : filtrer sur le package `front-service`, puis prendre `prod` ou le tag `sha-<full_sha>` du commit ciblé.
+- Dans le workflow GitHub Actions : lire le résumé de job (step summary) qui expose l'image, les deux tags et le digest final.
+- Côté infra : consommer idéalement le digest (`image@sha256:...`) pour un déploiement immuable.


### PR DESCRIPTION
### Motivation
- Consolidate image publication on the new branch strategy so the repo only publishes GHCR images from `prod` and remove legacy references to `master`/`main`/`latest`.
- Ensure infra can consume stable, immutable image coordinates and digests from a predictable image name.

### Description
- Update the publish workflow `/.github/workflows/publish-image.yml` to trigger only on `push` to `prod`, resolve the image name as `ghcr.io/<owner_lower>/front-service`, and publish exactly two tags: `prod` and `sha-<full_git_sha>`, while removing semver/ref/tag logic and any `master`/`main`/`latest` publication paths.
- Capture the digest output from `docker/build-push-action` and emit a readable job summary into `GITHUB_STEP_SUMMARY` showing the image, the two tags and the final digest with a reminder that infra should prefer deployment by digest.
- Keep `docker/metadata-action` but simplify its tags to the two required raw values and preserve basic OCI labels for clarity.
- Update the infra-focused documentation in `contract/deployment/README.md`, `contract/deployment/ghcr-tags.md` and `contract/deployment/compose.service.yaml` to reflect: publication only from `prod`, the image name `ghcr.io/<owner_lower>/front-service`, the published tags `prod` and `sha-<full_sha>`, that images are private, and that infra should preferentially deploy using the GHCR digest.
- No application code changes were made and the `Dockerfile` was left untouched.

Files modified:
- `.github/workflows/publish-image.yml`
- `contract/deployment/README.md`
- `contract/deployment/ghcr-tags.md`
- `contract/deployment/compose.service.yaml`

Expected final image coordinates:
- `ghcr.io/<owner_lower>/front-service:prod`
- `ghcr.io/<owner_lower>/front-service:sha-<full_git_sha>`
- Recommended infra consumption: `ghcr.io/<owner_lower>/front-service@sha256:<digest>` (pin by digest).

### Testing
- Ran `git diff --check` to ensure no whitespace errors and it passed.
- Ran `rg -n "master|main|latest" contract/deployment .github/workflows/publish-image.yml` to verify legacy references were removed and it returned only intended updated lines.
- Ran `git status --short` to confirm modified files are staged/tracked; the checks executed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2496e54448326a6a3cdaf250312d4)