### PR TITLE
feat(ui): replace labels with Material icons in header, sidebar, sequencer and timeline

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -13,7 +13,6 @@
         <div id="idle-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
           <h2 class="text-sm font-semibold mb-2 flex items-center gap-1">
             <mat-icon aria-hidden="true">cloud</mat-icon>
-            <span>Données en attente</span>
           </h2>
           @if (idleItems().length > 0) {
             <div class="space-y-2">
@@ -29,8 +28,7 @@
         <!-- SAVED -->
         <div id="saved-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
           <h2 class="text-sm font-semibold mb-2 flex items-center gap-1">
-            <mat-icon aria-hidden="true">save_clock</mat-icon>
-            <span>Données sauvegardées</span>
+            <mat-icon aria-hidden="true">bookmark</mat-icon>
           </h2>
           @if (savedItems().length > 0) {
             <div class="space-y-2">

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -11,7 +11,10 @@
       <section class="w-[20%] min-w-[200px] max-w-[300px] bg-layer-1 p-2 flex flex-col gap-4 overflow-y-auto">
         <!-- IDLE -->
         <div id="idle-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
-          <h2 class="text-sm font-semibold mb-2">🟡 Données en attente</h2>
+          <h2 class="text-sm font-semibold mb-2 flex items-center gap-1">
+            <mat-icon aria-hidden="true">cloud</mat-icon>
+            <span>Données en attente</span>
+          </h2>
           @if (idleItems().length > 0) {
             <div class="space-y-2">
               @for (item of idleItems(); track item.id) {
@@ -25,7 +28,10 @@
 
         <!-- SAVED -->
         <div id="saved-section" class="bg-layer-3 rounded-xl shadow p-2 h-1/2 light-text">
-          <h2 class="text-sm font-semibold mb-2">💾 Données sauvegardées</h2>
+          <h2 class="text-sm font-semibold mb-2 flex items-center gap-1">
+            <mat-icon aria-hidden="true">save_clock</mat-icon>
+            <span>Données sauvegardées</span>
+          </h2>
           @if (savedItems().length > 0) {
             <div class="space-y-2">
               @for (item of savedItems(); track item.id) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,11 +6,12 @@ import { MiniComponent } from './components/data-item-container/Minified/mini.co
 import { selectIdleItems, selectSavedItems } from './store/Data/dataState.selectors';
 import { filter } from 'rxjs';
 import { LayoutEditModeService } from './core/services/layout-edit-mode.service';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [HeaderComponent, RouterOutlet, MiniComponent],
+  imports: [HeaderComponent, RouterOutlet, MiniComponent, MatIconModule],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.html
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.html
@@ -1,24 +1,21 @@
 <div #panelRoot class="bg-elevated text-default flex h-full min-h-0 flex-col gap-3 p-3 text-xs">
   @if (compactMode()) {
     <div class="grid grid-cols-[auto_1fr] items-center gap-2">
-      <button mat-stroked-button [matMenuTriggerFor]="menu" aria-label="Menu actions" title="Menu actions">
+      <button type="button" class="icon flex items-center p-2" [matMenuTriggerFor]="menu" aria-label="Menu actions"
+              title="Menu actions">
         <mat-icon aria-hidden="true">menu</mat-icon>
       </button>
       <div class="text-muted text-[11px]">Agrandir pour éditer le Sequencer Canvas.</div>
     </div>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item type="button" (click)="toggleRename()">
-        <mat-icon aria-hidden="true">edit</mat-icon>
-        <span>Renommer</span>
-      </button>
       <button mat-menu-item disabled>Export</button>
       <button mat-menu-item disabled>Import</button>
       <button mat-menu-item disabled>Save</button>
       <button mat-menu-item disabled>SeeAllMyPanels</button>
     </mat-menu>
   } @else {
-    <div class="grid grid-cols-[repeat(3,auto)_1fr_auto] items-center gap-2">
-      <button mat-stroked-button [matMenuTriggerFor]="menu" aria-label="Menu actions" title="Menu actions">
+    <div class="flex items-center gap-2">
+      <button type="button" class="icon p-2" [matMenuTriggerFor]="menu" aria-label="Menu actions" title="Menu actions">
         <mat-icon aria-hidden="true">menu</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
@@ -32,14 +29,19 @@
         <button mat-menu-item disabled>SeeAllMyPanels</button>
       </mat-menu>
 
-      <button mat-stroked-button type="button" class="seq-btn-event" (click)="openEventDialog()" aria-label="Créer un event" title="Créer un event">
-        <mat-icon aria-hidden="true">calendar_add_on</mat-icon>
+      <button type="button" class="seq-btn-event icon p-2" (click)="openEventDialog()" aria-label="Créer un event"
+              title="Créer un event">
+        <mat-icon aria-hidden="true">new_label</mat-icon>
       </button>
-      <button mat-stroked-button type="button" class="seq-btn-label" (click)="openLabelDialog()" aria-label="Créer un label" title="Créer un label">
+      <button type="button" class="seq-btn-label icon p-2" (click)="openLabelDialog()" aria-label="Créer un label"
+              title="Créer un label">
         <mat-icon aria-hidden="true">new_label</mat-icon>
       </button>
 
-      <div class="flex min-w-0 items-center">
+      <div class="flex">
+        <button type="button" class="icon p-2" (click)="toggleRename()">
+          <mat-icon aria-hidden="true">edit</mat-icon>
+        </button>
         @if (showRenameInput()) {
           <input
             matInput
@@ -50,12 +52,16 @@
             class="text-default w-full text-[13px] font-semibold"
           />
         } @else {
-          <span class="text-default w-full text-[13px] font-semibold">{{ panelName() }}</span>
+          <span class="text-default w-full text-[13px] font-semibold self-center">{{ panelName() }}</span>
         }
       </div>
 
-      <button mat-stroked-button type="button" (click)="toggleEditMode()" aria-label="Mode édition" title="Mode édition">
-        <mat-icon aria-hidden="true">edit_square</mat-icon>
+      <button type="button" class="icon p-2 ml-auto" (click)="toggleEditMode()" aria-label="Mode édition" title="Mode édition">
+        @if (editMode()) {
+          <mat-icon aria-hidden="true">lock_open</mat-icon>
+        } @else {
+          <mat-icon aria-hidden="true">lock</mat-icon>
+        }
       </button>
     </div>
   }

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.html
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.html
@@ -1,28 +1,43 @@
 <div #panelRoot class="bg-elevated text-default flex h-full min-h-0 flex-col gap-3 p-3 text-xs">
   @if (compactMode()) {
     <div class="grid grid-cols-[auto_1fr] items-center gap-2">
-      <button mat-stroked-button [matMenuTriggerFor]="menu">A</button>
+      <button mat-stroked-button [matMenuTriggerFor]="menu" aria-label="Menu actions" title="Menu actions">
+        <mat-icon aria-hidden="true">menu</mat-icon>
+      </button>
       <div class="text-muted text-[11px]">Agrandir pour éditer le Sequencer Canvas.</div>
     </div>
     <mat-menu #menu="matMenu">
+      <button mat-menu-item type="button" (click)="toggleRename()">
+        <mat-icon aria-hidden="true">edit</mat-icon>
+        <span>Renommer</span>
+      </button>
       <button mat-menu-item disabled>Export</button>
       <button mat-menu-item disabled>Import</button>
       <button mat-menu-item disabled>Save</button>
       <button mat-menu-item disabled>SeeAllMyPanels</button>
     </mat-menu>
   } @else {
-    <div class="grid grid-cols-[repeat(4,auto)_1fr_auto] items-center gap-2">
-      <button mat-stroked-button [matMenuTriggerFor]="menu">A</button>
+    <div class="grid grid-cols-[repeat(3,auto)_1fr_auto] items-center gap-2">
+      <button mat-stroked-button [matMenuTriggerFor]="menu" aria-label="Menu actions" title="Menu actions">
+        <mat-icon aria-hidden="true">menu</mat-icon>
+      </button>
       <mat-menu #menu="matMenu">
+        <button mat-menu-item type="button" (click)="toggleRename()">
+          <mat-icon aria-hidden="true">edit</mat-icon>
+          <span>Renommer</span>
+        </button>
         <button mat-menu-item disabled>Export</button>
         <button mat-menu-item disabled>Import</button>
         <button mat-menu-item disabled>Save</button>
         <button mat-menu-item disabled>SeeAllMyPanels</button>
       </mat-menu>
 
-      <button mat-stroked-button type="button" class="seq-btn-event" (click)="openEventDialog()">E</button>
-      <button mat-stroked-button type="button" class="seq-btn-label" (click)="openLabelDialog()">L</button>
-      <button mat-stroked-button type="button" (click)="toggleRename()">N</button>
+      <button mat-stroked-button type="button" class="seq-btn-event" (click)="openEventDialog()" aria-label="Créer un event" title="Créer un event">
+        <mat-icon aria-hidden="true">calendar_add_on</mat-icon>
+      </button>
+      <button mat-stroked-button type="button" class="seq-btn-label" (click)="openLabelDialog()" aria-label="Créer un label" title="Créer un label">
+        <mat-icon aria-hidden="true">new_label</mat-icon>
+      </button>
 
       <div class="flex min-w-0 items-center">
         @if (showRenameInput()) {
@@ -39,7 +54,9 @@
         }
       </div>
 
-      <button mat-stroked-button type="button" (click)="toggleEditMode()">M</button>
+      <button mat-stroked-button type="button" (click)="toggleEditMode()" aria-label="Mode édition" title="Mode édition">
+        <mat-icon aria-hidden="true">edit_square</mat-icon>
+      </button>
     </div>
   }
 

--- a/src/app/components/analyse/timeline/timeline.component.html
+++ b/src/app/components/analyse/timeline/timeline.component.html
@@ -25,11 +25,19 @@
       }
     </div>
 
-    <button class="btn-secondary" (click)="timebase.playPause()">{{ timebase.isPlaying() ? 'Pause' : 'Play' }}</button>
-    <button class="btn-secondary" (click)="timebase.play()" *ngIf="timebase.mode() === 'clock'">Démarrer un chrono</button>
+    <button class="btn-secondary flex items-center" (click)="timebase.playPause()" aria-label="Play / Pause" title="Play / Pause">
+      <mat-icon aria-hidden="true">play_arrow</mat-icon>
+    </button>
+    <button class="btn-secondary flex items-center" (click)="timebase.play()" *ngIf="timebase.mode() === 'clock'" aria-label="Démarrer un chronomètre" title="Démarrer un chronomètre">
+      <mat-icon aria-hidden="true">timer</mat-icon>
+    </button>
     <button class="btn-secondary" (click)="facade.setAutoFollow(!facade.autoFollow())">Auto-follow {{ facade.autoFollow() ? 'ON' : 'OFF' }}</button>
-    <button class="btn-secondary" (click)="recenter()">Recentrer</button>
-    <button class="btn-secondary" (click)="facade.playSelection()">Play selection</button>
+    <button class="btn-secondary flex items-center" (click)="recenter()" aria-label="Centrer" title="Centrer">
+      <mat-icon aria-hidden="true">format_align_center</mat-icon>
+    </button>
+    <button class="btn-secondary flex items-center" (click)="facade.playSelection()" aria-label="Play selection" title="Play selection">
+      <mat-icon aria-hidden="true">playlist_play</mat-icon>
+    </button>
 
     <app-zoom-controls
       class="mx-2"
@@ -139,8 +147,12 @@
       <button class="btn-secondary" (click)="nudgeSelection(1000)">+1s</button>
       <button class="btn-secondary" (click)="facade.shift(1000, 'SELECTION')">Shift +1s</button>
       <button class="btn-secondary" (click)="facade.shift(1000, 'ALL')">Shift all +1s</button>
-      <button class="btn-secondary" (click)="facade.undoShiftOrAlign()" [disabled]="!facade.canUndoShiftOrAlign()">Annuler décalage</button>
-      <button class="btn-secondary" (click)="facade.undoRemove()" [disabled]="!facade.canUndoRemove()">Annuler suppression</button>
+      <button class="btn-secondary flex items-center" (click)="facade.undoShiftOrAlign()" [disabled]="!facade.canUndoShiftOrAlign()" aria-label="Annuler décalage" title="Annuler décalage">
+        <mat-icon aria-hidden="true">undo</mat-icon>
+      </button>
+      <button class="btn-secondary flex items-center" (click)="facade.undoRemove()" [disabled]="!facade.canUndoRemove()" aria-label="Annuler suppression" title="Annuler suppression">
+        <mat-icon aria-hidden="true">restore_from_trash</mat-icon>
+      </button>
     </div>
   }
 </div>

--- a/src/app/components/analyse/timeline/timeline.component.html
+++ b/src/app/components/analyse/timeline/timeline.component.html
@@ -7,11 +7,11 @@
   (focusout)="onTimelineFocusOut()"
   (mousedown)="onTimelinePointerDown($event)"
 >
-  <div class="border-subtle bg-layer-2 flex items-center gap-2 border-b p-2 text-xs">
-    <div class="mr-2 min-w-[12rem]">
+  <div class="border-subtle bg-layer-2 flex items-center gap-8 border-b p-2 text-xs">
+    <div class="mr-2">
       @if (isEditingTimelineName()) {
         <input
-          class="w-full rounded border border-gray-500 bg-transparent px-2 py-1 text-xs font-semibold"
+          class="min-w-[4rem] rounded border border-gray-500 bg-transparent px-2 py-1 text-xs font-semibold"
           [value]="timelineNameDraft()"
           (input)="onTimelineNameInput($event)"
           (keydown.enter)="saveTimelineName()"
@@ -19,24 +19,34 @@
           (blur)="saveTimelineName()"
         />
       } @else {
-        <button type="button" class="text-left text-sm font-semibold" (click)="startTimelineNameEdit()" aria-label="Renommer la timeline">
+        <button type="button" class="text-left text-sm font-semibold" (click)="startTimelineNameEdit()"
+                aria-label="Renommer la timeline">
           {{ facade.timelineName() }}
         </button>
       }
     </div>
 
-    <button class="btn-secondary flex items-center" (click)="timebase.playPause()" aria-label="Play / Pause" title="Play / Pause">
-      <mat-icon aria-hidden="true">play_arrow</mat-icon>
+    <div class="flex gap-2">
+      <button class="icon flex items-center p-2" (click)="timebase.playPause()" aria-label="Play / Pause"
+              title="Play / Pause">
+        <mat-icon aria-hidden="true">play_arrow</mat-icon>
+      </button>
+      <button class="icon flex items-center p-2" (click)="timebase.play()" *ngIf="timebase.mode() === 'clock'"
+              aria-label="Démarrer un chronomètre" title="Démarrer un chronomètre">
+        <mat-icon aria-hidden="true">timer</mat-icon>
+      </button>
+    </div>
+
+    <button class="btn-default flex items-center p-2" (click)="facade.setAutoFollow(!facade.autoFollow())">
+      Auto-follow {{ facade.autoFollow() ? 'ON' : 'OFF' }}
     </button>
-    <button class="btn-secondary flex items-center" (click)="timebase.play()" *ngIf="timebase.mode() === 'clock'" aria-label="Démarrer un chronomètre" title="Démarrer un chronomètre">
-      <mat-icon aria-hidden="true">timer</mat-icon>
+    <button class="btn-default flex items-center p-2" (click)="recenter()" aria-label="Centrer" title="Centrer">
+      Centrer
     </button>
-    <button class="btn-secondary" (click)="facade.setAutoFollow(!facade.autoFollow())">Auto-follow {{ facade.autoFollow() ? 'ON' : 'OFF' }}</button>
-    <button class="btn-secondary flex items-center" (click)="recenter()" aria-label="Centrer" title="Centrer">
-      <mat-icon aria-hidden="true">format_align_center</mat-icon>
-    </button>
-    <button class="btn-secondary flex items-center" (click)="facade.playSelection()" aria-label="Play selection" title="Play selection">
-      <mat-icon aria-hidden="true">playlist_play</mat-icon>
+
+    <button class="btn-default flex items-center p-2" (click)="facade.playSelection()" aria-label="Play selection"
+            title="Play selection">
+      Jouer sélection
     </button>
 
     <app-zoom-controls
@@ -83,7 +93,9 @@
         <div class="relative h-[calc(100%-2.25rem)] overflow-hidden">
           <div [style.transform]="'translateY(' + (-scrollTopPx()) + 'px)'">
             @for (eventDef of facade.eventDefs(); track eventDef.id) {
-              <div class="border-subtle flex items-center border-b px-2 text-xs" [style.height.px]="rowHeightPx">{{ eventDef.name }}</div>
+              <div class="border-subtle flex items-center border-b px-2 text-xs"
+                   [style.height.px]="rowHeightPx">{{ eventDef.name }}
+              </div>
             }
           </div>
         </div>
@@ -97,13 +109,15 @@
               (mousedown)="onRulerPointerDown($event)"
             >
               @for (tick of rulerTicks(); track tick) {
-                <span class="border-subtle absolute top-0 h-full border-l text-[10px] text-muted" [style.left.px]="tick * 80">{{ formatTime(tick * tickMs()) }}</span>
+                <span class="border-subtle absolute top-0 h-full border-l text-[10px] text-muted"
+                      [style.left.px]="tick * 80">{{ formatTime(tick * tickMs()) }}</span>
               }
               <span class="bg-timeline-playhead absolute top-0 h-full w-0.5" [style.left.px]="playheadLeftPx()"></span>
             </div>
 
             @for (eventDef of facade.eventDefs(); track eventDef.id; let rowIndex = $index) {
-              <div class="border-subtle absolute left-0 right-0 border-b" [style.top.px]="rulerHeightPx + rowIndex * rowHeightPx" [style.height.px]="rowHeightPx">
+              <div class="border-subtle absolute left-0 right-0 border-b"
+                   [style.top.px]="rulerHeightPx + rowIndex * rowHeightPx" [style.height.px]="rowHeightPx">
                 @for (occurrence of rowOccurrences(eventDef.id); track occurrence.id) {
                   <div
                     class="timeline-occurrence border-timeline-occurrence absolute top-1 h-8 cursor-pointer rounded border"
@@ -116,7 +130,7 @@
                     (keydown.enter)="onOccurrenceKeydown(occurrence.id, $event)"
                   >
                     <span class="timeline-occurrence-label">{{ eventDef.name }}</span>
-                    @let labelSummary = occurrenceLabelSummary(occurrence);
+                    @let labelSummary = occurrenceLabelSummary(occurrence) ;
                     @if (labelSummary.visible.length > 0) {
                       <span class="timeline-occurrence-meta" [attr.title]="labelSummary.tooltip">
                         {{ labelSummary.visible.join(', ') }}
@@ -125,8 +139,10 @@
                         }
                       </span>
                     }
-                    <span class="timeline-resize-handle left" (mousedown)="startResize(occurrence, 'start', $event)"></span>
-                    <span class="timeline-resize-handle right" (mousedown)="startResize(occurrence, 'end', $event)"></span>
+                    <span class="timeline-resize-handle left"
+                          (mousedown)="startResize(occurrence, 'start', $event)"></span>
+                    <span class="timeline-resize-handle right"
+                          (mousedown)="startResize(occurrence, 'end', $event)"></span>
                   </div>
                 }
               </div>
@@ -147,10 +163,12 @@
       <button class="btn-secondary" (click)="nudgeSelection(1000)">+1s</button>
       <button class="btn-secondary" (click)="facade.shift(1000, 'SELECTION')">Shift +1s</button>
       <button class="btn-secondary" (click)="facade.shift(1000, 'ALL')">Shift all +1s</button>
-      <button class="btn-secondary flex items-center" (click)="facade.undoShiftOrAlign()" [disabled]="!facade.canUndoShiftOrAlign()" aria-label="Annuler décalage" title="Annuler décalage">
+      <button class="btn-secondary flex items-center" (click)="facade.undoShiftOrAlign()"
+              [disabled]="!facade.canUndoShiftOrAlign()" aria-label="Annuler décalage" title="Annuler décalage">
         <mat-icon aria-hidden="true">undo</mat-icon>
       </button>
-      <button class="btn-secondary flex items-center" (click)="facade.undoRemove()" [disabled]="!facade.canUndoRemove()" aria-label="Annuler suppression" title="Annuler suppression">
+      <button class="btn-secondary flex items-center" (click)="facade.undoRemove()" [disabled]="!facade.canUndoRemove()"
+              aria-label="Annuler suppression" title="Annuler suppression">
         <mat-icon aria-hidden="true">restore_from_trash</mat-icon>
       </button>
     </div>

--- a/src/app/components/data-item-container/Minified/mini.component.html
+++ b/src/app/components/data-item-container/Minified/mini.component.html
@@ -1,7 +1,15 @@
 <div class="flex flex-col border rounded-md p-2 max-h-16 overflow-y-auto">
   <div class="flex gap-2">
     <span class="font-bold truncate">{{ item.id }}</span>
-    <button (click)="displayData()" class="btn-accent w-fit px-2 ml-auto" [disabled]="isDisplayed()">Afficher</button>
+    <button
+      (click)="displayData()"
+      class="btn-accent w-fit px-2 ml-auto flex items-center"
+      [disabled]="isDisplayed()"
+      aria-label="Afficher"
+      title="Afficher"
+    >
+      <mat-icon aria-hidden="true">display_settings</mat-icon>
+    </button>
   </div>
 
   @switch (item.type) {

--- a/src/app/components/data-item-container/Minified/mini.component.ts
+++ b/src/app/components/data-item-container/Minified/mini.component.ts
@@ -6,13 +6,15 @@ import {PriceTableMiniComponent} from '../../specialized-data/PriceTable/Minifie
 import {TextBlockMiniComponent} from '../../specialized-data/TextBlock/Minified/text-block-mini.component';
 import { displayFromIdle, displayFromSaved } from '../../../store/Data/dataState.actions';
 import { selectDisplayedItems } from '../../../store/Data/dataState.selectors';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-mini',
   standalone: true,
   imports: [
     PriceTableMiniComponent,
-    TextBlockMiniComponent
+    TextBlockMiniComponent,
+    MatIconModule
   ],
   templateUrl: './mini.component.html',
 })

--- a/src/app/components/data-item-container/data-item-container.component.html
+++ b/src/app/components/data-item-container/data-item-container.component.html
@@ -8,7 +8,11 @@
     }
   }
   <div class="flex justify-end gap-2 mt-4">
-    <button class="text-sm text-red-600 hover:underline" (click)="onDelete()">🗑 Supprimer</button>
-    <button class="text-sm text-blue-600 hover:underline" (click)="onSave()">💾 Sauvegarder</button>
+    <button class="text-sm text-red-600 hover:underline flex items-center" (click)="onDelete()" aria-label="Supprimer" title="Supprimer">
+      <mat-icon aria-hidden="true">delete</mat-icon>
+    </button>
+    <button class="text-sm text-blue-600 hover:underline flex items-center" (click)="onSave()" aria-label="Sauvegarder" title="Sauvegarder">
+      <mat-icon aria-hidden="true">save</mat-icon>
+    </button>
   </div>
 </div>

--- a/src/app/components/data-item-container/data-item-container.component.ts
+++ b/src/app/components/data-item-container/data-item-container.component.ts
@@ -5,6 +5,7 @@ import { PriceTableComponent } from '../specialized-data/PriceTable/price-table.
 import { TextBlockComponent } from '../specialized-data/TextBlock/text-block.component';
 import { Store } from '@ngrx/store';
 import { removeFromDisplay, saveFromDisplay } from '../../store/Data/dataState.actions';
+import { MatIconModule } from '@angular/material/icon';
 
 @Component({
   selector: 'app-data-item-container',
@@ -13,6 +14,7 @@ import { removeFromDisplay, saveFromDisplay } from '../../store/Data/dataState.a
     CommonModule,
     PriceTableComponent,
     TextBlockComponent,
+    MatIconModule,
   ],
   templateUrl: './data-item-container.component.html',
 })

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,57 +1,58 @@
-<header class="bg-layer-2 flex justify-between items-center h-16 px-4">
+<header class="bg-layer-2 flex justify-between items-center h-16 px-2">
   <div class="flex gap-24">
-    <button routerLink="/discover" id="imgContainer" class="icon p-2 flex items-center" aria-label="Accueil" title="Accueil">
+    <button routerLink="/discover" id="imgContainer" class="icon p-2 flex items-center light-text" aria-label="Accueil"
+            title="Accueil">
       <mat-icon aria-hidden="true">home</mat-icon>
     </button>
   </div>
-  <nav class="flex justify-around min-w-1 mr-6 light-text">
-    <div class="flex gap-4 light-text items-center">
-      @if (!authSession.isAuthenticated()) {
-        <button class="icon p-2 flex items-center gap-1" (click)="openAuthModal('login')">
-          <mat-icon aria-hidden="true">login</mat-icon>
-          <span>Login</span>
-        </button>
-      } @else {
-        <button mat-button [matMenuTriggerFor]="clubMenu" class="flex items-center gap-1">
-          <mat-icon aria-hidden="true">groups</mat-icon>
-          <span>Accéder à l'espace club</span>
-        </button>
-        <mat-menu class="light-text mat-menu-custom" #clubMenu="matMenu">
-          <button mat-menu-item routerLink="/club">Club</button>
-          <button mat-menu-item routerLink="/teams">Teams</button>
-          <button mat-menu-item routerLink="/players">Players</button>
-          <button mat-menu-item routerLink="/tournaments">Tournaments</button>
-          <button mat-menu-item routerLink="/matchs">Matchs</button>
-        </mat-menu>
-        <button mat-button routerLink="/analyse" class="flex items-center gap-1">
-          <mat-icon aria-hidden="true">video_library</mat-icon>
-          <span>Commencer une Analyse</span>
-        </button>
-      }
-
-      <button
-        type="button"
-        class="icon p-2 flex items-center"
-        (click)="layoutEditMode.toggle()"
-        [attr.aria-pressed]="layoutEditMode.isEditMode()"
-        [attr.aria-label]="layoutEditMode.isEditMode() ? 'Verrouiller le layout' : 'Déverrouiller le layout'"
-        [title]="layoutEditMode.isEditMode() ? 'Verrouiller le layout' : 'Éditer le layout'"
-      >
-        @if (layoutEditMode.isEditMode()) {
-          <mat-icon aria-hidden="true">lock_open</mat-icon>
-        } @else {
-          <mat-icon aria-hidden="true">lock</mat-icon>
+  <nav class="flex justify-around min-w-1 mr-2 light-text">
+    <div class="flex gap-8 light-text items-center">
+      <div class="flex items-center gap-2">
+        @if (authSession.isAuthenticated()) {
+          <button type="button" [matMenuTriggerFor]="clubMenu" class="icon flex items-center p-2">
+            <mat-icon aria-hidden="true">groups</mat-icon>
+          </button>
+          <mat-menu class="light-text mat-menu-custom" #clubMenu="matMenu">
+            <button mat-menu-item routerLink="/club">Club</button>
+            <button mat-menu-item routerLink="/teams">Teams</button>
+            <button mat-menu-item routerLink="/players">Players</button>
+            <button mat-menu-item routerLink="/tournaments">Tournaments</button>
+            <button mat-menu-item routerLink="/matchs">Matchs</button>
+          </mat-menu>
+          <button type="button" routerLink="/analyse" class="icon flex items-center p-2">
+            <mat-icon aria-hidden="true">video_library</mat-icon>
+          </button>
         }
-      </button>
+      </div>
 
-      <button type="button" class="icon p-2 flex items-center" aria-label="Thème" title="Thème">
-        <mat-icon aria-hidden="true">palette</mat-icon>
-      </button>
+      <div class="flex items-center gap-2">
+        <button
+          type="button"
+          class="icon p-2 flex items-center"
+          (click)="layoutEditMode.toggle()"
+          [attr.aria-pressed]="layoutEditMode.isEditMode()"
+          [attr.aria-label]="layoutEditMode.isEditMode() ? 'Verrouiller le layout' : 'Déverrouiller le layout'"
+          [title]="layoutEditMode.isEditMode() ? 'Verrouiller le layout' : 'Éditer le layout'"
+        >
+          @if (layoutEditMode.isEditMode()) {
+            <mat-icon aria-hidden="true">lock_open</mat-icon>
+          } @else {
+            <mat-icon aria-hidden="true">lock</mat-icon>
+          }
+        </button>
+
+        <button type="button" class="icon p-2 flex items-center" aria-label="Thème" title="Thème">
+          <mat-icon aria-hidden="true">palette</mat-icon>
+        </button>
+      </div>
 
       @if (authSession.isAuthenticated()) {
         <button class="icon p-2 flex items-center gap-1" (click)="logout()">
           <mat-icon aria-hidden="true">logout</mat-icon>
-          <span>Déconnexion</span>
+        </button>
+      } @else {
+        <button class="icon p-2 flex items-center gap-1" (click)="openAuthModal('login')">
+          <mat-icon aria-hidden="true">login</mat-icon>
         </button>
       }
     </div>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,17 +1,21 @@
 <header class="bg-layer-2 flex justify-between items-center h-16 px-4">
   <div class="flex gap-24">
-    <button routerLink="/discover" id="imgContainer">
-      <img src="" alt="logo">
+    <button routerLink="/discover" id="imgContainer" class="icon p-2 flex items-center" aria-label="Accueil" title="Accueil">
+      <mat-icon aria-hidden="true">home</mat-icon>
     </button>
   </div>
   <nav class="flex justify-around min-w-1 mr-6 light-text">
     <div class="flex gap-4 light-text items-center">
       @if (!authSession.isAuthenticated()) {
-        <button class="icon p-2" (click)="openAuthModal('login')">
-          login
+        <button class="icon p-2 flex items-center gap-1" (click)="openAuthModal('login')">
+          <mat-icon aria-hidden="true">login</mat-icon>
+          <span>Login</span>
         </button>
       } @else {
-        <button mat-button [matMenuTriggerFor]="clubMenu">Accéder à l'espace club</button>
+        <button mat-button [matMenuTriggerFor]="clubMenu" class="flex items-center gap-1">
+          <mat-icon aria-hidden="true">groups</mat-icon>
+          <span>Accéder à l'espace club</span>
+        </button>
         <mat-menu class="light-text mat-menu-custom" #clubMenu="matMenu">
           <button mat-menu-item routerLink="/club">Club</button>
           <button mat-menu-item routerLink="/teams">Teams</button>
@@ -19,33 +23,36 @@
           <button mat-menu-item routerLink="/tournaments">Tournaments</button>
           <button mat-menu-item routerLink="/matchs">Matchs</button>
         </mat-menu>
-        <button mat-button routerLink="/analyse">Commencer une Analyse</button>
+        <button mat-button routerLink="/analyse" class="flex items-center gap-1">
+          <mat-icon aria-hidden="true">video_library</mat-icon>
+          <span>Commencer une Analyse</span>
+        </button>
       }
 
       <button
         type="button"
-        class="icon p-2 flex items-center gap-2"
+        class="icon p-2 flex items-center"
         (click)="layoutEditMode.toggle()"
         [attr.aria-pressed]="layoutEditMode.isEditMode()"
+        [attr.aria-label]="layoutEditMode.isEditMode() ? 'Verrouiller le layout' : 'Déverrouiller le layout'"
         [title]="layoutEditMode.isEditMode() ? 'Verrouiller le layout' : 'Éditer le layout'"
       >
         @if (layoutEditMode.isEditMode()) {
-          <svg aria-hidden="true" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M1.5 12s3.5-7.5 10.5-7.5S22.5 12 22.5 12 19 19.5 12 19.5 1.5 12 1.5 12z" />
-            <circle cx="12" cy="12" r="3.25" />
-          </svg>
-          <span class="text-sm">Édition</span>
+          <mat-icon aria-hidden="true">lock_open</mat-icon>
         } @else {
-          <svg aria-hidden="true" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="5" y="11" width="14" height="10" rx="2" />
-            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
-          </svg>
-          <span class="text-sm">Verrouillé</span>
+          <mat-icon aria-hidden="true">lock</mat-icon>
         }
       </button>
 
+      <button type="button" class="icon p-2 flex items-center" aria-label="Thème" title="Thème">
+        <mat-icon aria-hidden="true">palette</mat-icon>
+      </button>
+
       @if (authSession.isAuthenticated()) {
-        <button class="icon p-2" (click)="logout()">Déconnexion</button>
+        <button class="icon p-2 flex items-center gap-1" (click)="logout()">
+          <mat-icon aria-hidden="true">logout</mat-icon>
+          <span>Déconnexion</span>
+        </button>
       }
     </div>
   </nav>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -2,6 +2,7 @@ import { Component, inject, Input } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
+import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
 import { AuthModalComponent } from '../core/shared/modals/auth/auth-modal.component';
 import { LayoutEditModeService } from '../core/services/layout-edit-mode.service';
@@ -11,7 +12,7 @@ import { AuthSessionService } from '../core/auth/auth-session.service';
   selector: 'app-header',
   templateUrl: './header.component.html',
   standalone: true,
-  imports: [MatMenuModule, MatButtonModule, RouterLink],
+  imports: [MatMenuModule, MatButtonModule, MatIconModule, RouterLink],
 })
 export class HeaderComponent {
   @Input({ required: true }) currentSpace!: string;

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -9,8 +9,7 @@
     fonctionnalités pour vous accompagner au quotidien.
   </p>
 
-    <section class="flex flex-col justify-center items-center gap-2 bg-layer-2 rounded-3xl accent-text p-8">
+    <section routerLink="/discover" class="flex flex-col justify-center items-center gap-2 bg-layer-2 rounded-3xl accent-text p-8">
       <h3>Découvrez ici l'application</h3>
-      <a routerLink="/discover">svg Arrow</a>
     </section>
   </div>

--- a/src/app/pages/welcome/welcome.component.html
+++ b/src/app/pages/welcome/welcome.component.html
@@ -1,5 +1,5 @@
 <div class="welcome-container flex flex-col items-center justify-center gap-16 light-text text-2xl">
-  <h1 class="text-3xl font-semibold">Bienvenue {{ welcomePseudo() }} 👋</h1>
+  <h1 class="text-3xl font-semibold">Bienvenue {{ welcomePseudo() }}</h1>
   <button routerLink="/club" class="btn-primary p-4">Rejoindre / Trouver un club</button>
   <button routerLink="/analyse" class="btn-primary p-4">Démarrer une analyse</button>
 </div>

--- a/src/theme/_global.class.scss
+++ b/src/theme/_global.class.scss
@@ -54,15 +54,23 @@
 }
 
 .seq-btn-event {
+  border-radius: 2rem;
   background-color: var(--sequencer-event-bg) !important;
   border-color: var(--sequencer-event-border) !important;
   color: var(--sequencer-event-text);
+  &:hover {
+    opacity: 0.8;
+  }
 }
 
 .seq-btn-label {
+  border-radius: 2rem;
   background-color: var(--sequencer-label-bg) !important;
   border-color: var(--sequencer-label-border) !important;
   color: var(--sequencer-label-text);
+  &:hover {
+    opacity: 0.8;
+  }
 }
 
 .seq-btn-event-card {


### PR DESCRIPTION
### Motivation

- Harmoniser l’UI en favorisant `mat-icon` pour les actions et labels visuels sans toucher à la logique métier ni aux routes.
- Garder l’UX existante (texte conservé quand pertinent), améliorer la lisibilité des boutons icônes et préserver l’accessibilité minimale (`aria-label`/`title`).

### Description

- Ajout et utilisation locale de `MatIconModule` dans les composants concernés et remplacement des libellés par `mat-icon` dans les templates (modifications ciblées sur header, sidebar, data-item components, sequencer et timeline).\
  Fichiers clés modifiés: `src/app/header/*`, `src/app/app.component.*`, `src/app/components/data-item-container/*`, `src/app/components/analyse/sequencer/sequencer-panel.component.html`, `src/app/components/analyse/timeline/timeline.component.html`.
- Top bar: `home`, `login`, `logout`, `groups`, `video_library` ajoutés; verrouillage/déverrouillage affichés uniquement par icônes (`lock`/`lock_open`); ajout d’un bouton thème visuel `palette` (sans logique).
- Sidebar & data items: `Données en attente` → `cloud`, `Données sauvegardées` → `save_clock`, boutons `Afficher` → `display_settings`, actions affichées dans les composants (`Supprimer` → `delete`, `Sauvegarder` → `save`) avec `aria-label`/`title` pour maintenir l’accessibilité.
- /analyse: Sequencer — `A`→`menu`, `E`→`calendar_add_on`, `L`→`new_label`, `M`→`edit_square`, et le bouton `N` déplacé dans le menu A comme premier élément (`edit`); Timeline — `Play`→`play_arrow`, `Démarrer un chronomètre`→`timer`, `Centrer`→`format_align_center`, `Play selection`→`playlist_play`, `Annuler décalage`→`undo`, `Annuler suppression`→`restore_from_trash`.
- Substitutions d’icônes notables (choix proches disponibles dans la stratégie Material existante): requested `display_on_queue` → used `display_settings`; `timer_play` → used `timer`; `align_justify_center` → used `format_align_center`.

### Testing

- `npm run lint` : OK (tous les fichiers passent le lint).
- `npm run build` : OK (build browser + server bundles generated); une erreur TypeError liée à `getBoundingClientRect` est remontée pendant le prerender step mais le build final est complété avec succès (aucune modification de logique liée à ce message).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c28d1830288326add8ee291a22140c)