### PR TITLE
feat(sequencer): add stats buttons with live simple/complex evaluation

### DIFF
--- a/codex.md
+++ b/codex.md
@@ -243,3 +243,33 @@ Checklist
 - UI Timeline (`src/app/components/analyse/timeline/*`) : layout 2 colonnes (liste events fixe + zone temps), ruler sticky, viewport scrollable X/Y, sélection simple/multi, handles resize, selection tools en footer, auto-follow contextuel + recenter.
 - Mode sans vidéo : empty state + CTA chrono ; work duration tamponnée (`bufferWorkDurationMs`) pour conserver un espace de travail en faux live.
 - Schéma/version : utilitaires dédiés (`src/app/utils/timeline/timeline-version.utils.ts`) avec regex stricte `^\d+\.\d+\.\d+$` et helpers validate/format/compare.
+
+## 19) Sequencer Stats Buttons (V1)
+- Nouveau type de bouton natif `stat` dans `SequencerBtn` avec payload `stat` sérialisable :
+  - mode `simple` avec `query: { eventIds[], labelIds[], metric:'count', labelMatch:'all' }`
+  - mode `complex` avec expression JSON arborescente (`constant`, `query`, `group` + opérateurs `+ - * /`).
+- Topbar sequencer (`/analyse`) : bouton **Stats** (`query_stats`) pour créer un bouton `stat`.
+- Canvas :
+  - un bouton `stat` est rendu comme un vrai bouton (layout drag/resize inchangé),
+  - en mode run il affiche `name + valeur live`, informatif uniquement (aucune action timeline au clic/hotkey),
+  - l’icône `gesture_select` ouvre la configuration de stats en mode édition.
+- Service dédié `SequencerStatsService` (signals/computed) :
+  - centralise le calcul de stats à partir des occurrences d’analyse,
+  - évalue les requêtes simples (`count`) et expressions complexes,
+  - renvoie les valeurs live + une sortie structurée (`exportRows`) pour futur export Excel.
+- Règles métier V1 :
+  - matching simple = `eventDefId ∈ eventIds` AND tous les labels demandés sont présents,
+  - `labelMatch` implémenté uniquement en `all`,
+  - division par zéro / calcul invalide => `null` (affichage `—`).
+- Affichage des valeurs :
+  - arrondi d’affichage uniquement,
+  - entier sans décimales,
+  - décimal avec maximum 2 décimales.
+- Import/export JSON sequencer :
+  - `SequencerPanelService.exportAsJson()` / `importFromJson()` prennent en charge `event`, `label`, `stat`,
+  - la définition de stats reste stockée dans chaque bouton `stat` (source de vérité unique).
+- Limites connues V1 :
+  - pas de `%`, pas de parser texte libre,
+  - pas de référence inter-boutons stats,
+  - pas de métriques de durée (count seulement),
+  - `labelMatch: 'any'` non implémenté (prévu plus tard).

--- a/codex.md
+++ b/codex.md
@@ -248,7 +248,7 @@ Checklist
 - Nouveau type de bouton natif `stat` dans `SequencerBtn` avec payload `stat` sérialisable :
   - mode `simple` avec `query: { eventIds[], labelIds[], metric:'count', labelMatch:'all' }`
   - mode `complex` évalué sur AST (`constant`, `query`, `group` + opérateurs `+ - * /`).
-  - UX d’édition complexe orientée expression mathématique visuelle : termes (`A`, `B`, `C`...) + tokens (`terme`, opérateur, parenthèses), sans champ “priorité”.
+  - UX d’édition complexe orientée expression mathématique visuelle : termes nommables librement (nom métier) + tokens (`terme`, opérateur, parenthèses), sans champ “priorité”.
 - Topbar sequencer (`/analyse`) : bouton **Stats** (`query_stats`) pour créer un bouton `stat`.
 - Canvas :
   - un bouton `stat` est rendu comme un vrai bouton (layout drag/resize inchangé),
@@ -268,8 +268,9 @@ Checklist
   - entier sans décimales,
   - décimal avec maximum 2 décimales.
 - Validation UX modale stats :
-  - couleur prévisualisée (swatch + mini aperçu bouton),
+  - couleur prévisualisée via swatch simple,
   - mode simple valide uniquement si au moins un event est sélectionné,
+  - couleurs de labels configurables côté stats (`labelColorById`) pour simple et termes requête en complexe,
   - mode complexe valide avec expression complète (tokens), parenthèses équilibrées, termes valides,
   - division statique par zéro bloquée à la configuration (division dynamique laissée au runtime, affichée `—`).
 - Import/export JSON sequencer :

--- a/codex.md
+++ b/codex.md
@@ -247,12 +247,14 @@ Checklist
 ## 19) Sequencer Stats Buttons (V1)
 - Nouveau type de bouton natif `stat` dans `SequencerBtn` avec payload `stat` sérialisable :
   - mode `simple` avec `query: { eventIds[], labelIds[], metric:'count', labelMatch:'all' }`
-  - mode `complex` avec expression JSON arborescente (`constant`, `query`, `group` + opérateurs `+ - * /`).
+  - mode `complex` évalué sur AST (`constant`, `query`, `group` + opérateurs `+ - * /`).
+  - UX d’édition complexe orientée expression mathématique visuelle : termes (`A`, `B`, `C`...) + tokens (`terme`, opérateur, parenthèses), sans champ “priorité”.
 - Topbar sequencer (`/analyse`) : bouton **Stats** (`query_stats`) pour créer un bouton `stat`.
 - Canvas :
   - un bouton `stat` est rendu comme un vrai bouton (layout drag/resize inchangé),
   - en mode run il affiche `name + valeur live`, informatif uniquement (aucune action timeline au clic/hotkey),
-  - l’icône `gesture_select` ouvre la configuration de stats en mode édition.
+  - l’icône `gesture_select` ouvre la configuration de stats en mode édition,
+  - la modale est scrollable verticalement (header/actions stables) pour gérer de longues expressions.
 - Service dédié `SequencerStatsService` (signals/computed) :
   - centralise le calcul de stats à partir des occurrences d’analyse,
   - évalue les requêtes simples (`count`) et expressions complexes,
@@ -265,6 +267,11 @@ Checklist
   - arrondi d’affichage uniquement,
   - entier sans décimales,
   - décimal avec maximum 2 décimales.
+- Validation UX modale stats :
+  - couleur prévisualisée (swatch + mini aperçu bouton),
+  - mode simple valide uniquement si au moins un event est sélectionné,
+  - mode complexe valide avec expression complète (tokens), parenthèses équilibrées, termes valides,
+  - division statique par zéro bloquée à la configuration (division dynamique laissée au runtime, affichée `—`).
 - Import/export JSON sequencer :
   - `SequencerPanelService.exportAsJson()` / `importFromJson()` prennent en charge `event`, `label`, `stat`,
   - la définition de stats reste stockée dans chaque bouton `stat` (source de vérité unique).

--- a/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.html
+++ b/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.html
@@ -14,6 +14,7 @@
             [class.seq-btn-event-card]="btn.type === 'event'"
             [class.seq-btn-label]="btn.type === 'label'"
             [class.seq-btn-event-active]="btn.type === 'event' && isActive(btn.id)"
+            [class.seq-btn-stat]="btn.type === 'stat'"
             [ngStyle]="btnStyle(btn)"
             [class.is-pressed]="lastTriggeredBtnId === btn.id"
             (mousedown)="onBtnMouseDown($event, btn)"
@@ -26,7 +27,7 @@
                   class="flex h-4 w-4 min-h-4 min-w-4 items-center justify-center"
                   (click)="onEditIconClick($event, btn)"
                 >
-                  <mat-icon class="h-3 w-3 text-[12px]">edit</mat-icon>
+                  <mat-icon class="h-3 w-3 text-[12px]">{{ btn.type === 'stat' ? 'gesture_select' : 'edit' }}</mat-icon>
                 </button>
               </div>
               <div class="absolute right-1 top-1 z-20">
@@ -43,9 +44,12 @@
             <div class="min-w-0 max-w-full px-1">
               <div class="text-[10px] font-medium">{{ btn.id }}</div>
               <div class="truncate text-xs font-semibold">{{ btn.name }}</div>
+              @if (btn.type === 'stat') {
+                <div class="text-sm font-bold">{{ getStatDisplayValue(btn.id) }}</div>
+              }
             </div>
 
-            <div class="w-full text-[10px]">{{ formatHotkey(btn.hotkeyNormalized) }}</div>
+            <div class="w-full text-[10px]">{{ btn.type === 'stat' ? 'Live stat' : formatHotkey(btn.hotkeyNormalized) }}</div>
 
             @if (editMode) {
               <span

--- a/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.ts
+++ b/src/app/components/analyse/sequencer/canvas/sequencer-canvas.component.ts
@@ -18,6 +18,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { SequencerPanelService } from '../../../../core/service/sequencer-panel.service';
 import { SequencerZoomService } from '../../../../core/services/sequencer-zoom.service';
+import { SequencerStatsService } from '../../../../core/services/sequencer-stats.service';
 import { SequencerBtn } from '../../../../interfaces/sequencer-btn.interface';
 import {
   contentMinHeightPx,
@@ -44,8 +45,10 @@ export class SequencerCanvasComponent implements AfterViewInit, OnDestroy {
 
   private readonly minZoomContainerPx = 250;
   private readonly defaultEventColor = '#1F3D28';
+  private readonly defaultStatColor = '#1f4b73';
   private readonly panelService = inject(SequencerPanelService);
   readonly sequencerZoom = inject(SequencerZoomService);
+  readonly statsService = inject(SequencerStatsService);
   readonly containerWidthPx = signal(0);
   readonly showZoom = computed(() => this.containerWidthPx() >= this.minZoomContainerPx);
 
@@ -158,8 +161,8 @@ export class SequencerCanvasComponent implements AfterViewInit, OnDestroy {
       zIndex: `${layout.z ?? 1}`,
     };
 
-    if (btn.type === 'event') {
-      const background = btn.colorHex || this.defaultEventColor;
+    if (btn.type === 'event' || btn.type === 'stat') {
+      const background = btn.colorHex || (btn.type === 'event' ? this.defaultEventColor : this.defaultStatColor);
       style['backgroundColor'] = background;
       style['color'] = getReadableTextColor(background);
     }
@@ -278,7 +281,7 @@ export class SequencerCanvasComponent implements AfterViewInit, OnDestroy {
 
   onBtnClick(event: MouseEvent, btn: SequencerBtn) {
     event.stopPropagation();
-    if (this.editMode) {
+    if (this.editMode || btn.type === 'stat') {
       return;
     }
     this.triggerBtn.emit(btn);
@@ -300,6 +303,10 @@ export class SequencerCanvasComponent implements AfterViewInit, OnDestroy {
 
   formatHotkey(normalized?: string | null) {
     return formatNormalizedHotkey(normalized) || '—';
+  }
+
+  getStatDisplayValue(btnId: string) {
+    return this.statsService.getDisplayValue(btnId);
   }
 
   private clampLayoutWithinCanvas(btnId: string, patch: { x?: number; y?: number; w?: number; h?: number }) {

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
@@ -2,8 +2,8 @@
   {{ isEdit ? 'Éditer un Stat' : 'Créer un Stat' }}
 </h2>
 
-<mat-dialog-content class="bg-layer-3 light-text pt-3">
-  <form [formGroup]="form" class="flex flex-col gap-4">
+<mat-dialog-content class="bg-layer-3 light-text stats-dialog-content">
+  <form [formGroup]="form" class="flex flex-col gap-4 pb-2">
     <div class="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-3">
       <mat-form-field appearance="fill">
         <mat-label>ID</mat-label>
@@ -15,9 +15,22 @@
       </mat-form-field>
     </div>
 
-    <div class="flex items-center gap-3">
-      <label for="stat-color" class="text-xs font-semibold">Couleur</label>
-      <input id="stat-color" type="color" formControlName="colorHex" class="timeline-color-input" />
+    <div class="border-layer rounded-md border p-3">
+      <div class="mb-2 text-[13px] font-semibold">Couleur du bouton</div>
+      <div class="grid grid-cols-1 gap-3 md:grid-cols-[auto_1fr] md:items-center">
+        <input id="stat-color" type="color" formControlName="colorHex" class="timeline-color-input" />
+
+        <div class="flex flex-wrap items-center gap-3">
+          <div class="h-8 w-8 rounded border border-layer" [style.background]="colorPreview()"></div>
+          <div class="rounded-md border border-layer px-3 py-2 text-xs" [style.background]="colorPreview()" [style.color]="'#fff'">
+            Aperçu bouton stats
+          </div>
+          <span class="text-xs text-muted">{{ colorPreview() }}</span>
+        </div>
+      </div>
+      @if (colorError()) {
+        <div class="alert-text mt-2 text-xs">{{ colorError() }}</div>
+      }
     </div>
 
     <mat-radio-group class="flex justify-center gap-2" [formControl]="modeControl">
@@ -30,7 +43,7 @@
         <div class="text-[13px] font-semibold mb-2">Requête simple</div>
         <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
           <mat-form-field appearance="fill">
-            <mat-label>Events ciblés</mat-label>
+            <mat-label>Events ciblés *</mat-label>
             <mat-select [value]="simpleEventIds()" (valueChange)="simpleEventIds.set($event)" multiple>
               @for (event of availableEvents(); track event.id) {
                 <mat-option [value]="event.id">{{ event.id }} · {{ event.name }}</mat-option>
@@ -46,22 +59,19 @@
             </mat-select>
           </mat-form-field>
         </div>
+        @if (simpleError()) {
+          <div class="alert-text text-xs">{{ simpleError() }}</div>
+        }
       </div>
     } @else {
       <div class="border-layer rounded-md border p-3 flex flex-col gap-3">
-        <div class="flex items-center justify-between">
-          <div class="text-[13px] font-semibold">Expression complexe</div>
-          <button mat-stroked-button type="button" (click)="addComplexTerm()">
-            <mat-icon>add</mat-icon>
-            Ajouter un terme
-          </button>
-        </div>
+        <div class="text-[13px] font-semibold">Termes disponibles</div>
 
         @for (term of complexTerms(); track $index) {
           <div class="border-layer rounded-md border p-2">
             <div class="flex items-center justify-between mb-2">
-              <div class="text-[12px] font-semibold">Opérande {{ $index + 1 }}</div>
-              <button mat-icon-button type="button" [disabled]="complexTerms().length <= 2" (click)="removeComplexTerm($index)">
+              <div class="text-[12px] font-semibold">{{ aliasList()[$index] }} = {{ term.kind === 'query' ? 'Requête' : 'Constante' }}</div>
+              <button mat-icon-button type="button" [disabled]="complexTerms().length <= 1" (click)="removeComplexTerm($index)">
                 <mat-icon>delete</mat-icon>
               </button>
             </div>
@@ -82,7 +92,7 @@
                 </mat-form-field>
               } @else {
                 <mat-form-field appearance="fill">
-                  <mat-label>Events</mat-label>
+                  <mat-label>Events *</mat-label>
                   <mat-select [value]="term.eventIds" (valueChange)="updateTerm($index, { eventIds: $event })" multiple>
                     @for (event of availableEvents(); track event.id) {
                       <mat-option [value]="event.id">{{ event.id }} · {{ event.name }}</mat-option>
@@ -99,35 +109,56 @@
                 </mat-form-field>
               }
             </div>
-
-            @if ($index < complexOperators().length) {
-              <div class="mt-3 grid gap-2 md:grid-cols-2">
-                <mat-form-field appearance="fill">
-                  <mat-label>Opérateur</mat-label>
-                  <mat-select [value]="complexOperators()[$index].op" (valueChange)="updateOperator($index, { op: $event })">
-                    <mat-option value="+">+</mat-option>
-                    <mat-option value="-">-</mat-option>
-                    <mat-option value="*">*</mat-option>
-                    <mat-option value="/">/</mat-option>
-                  </mat-select>
-                </mat-form-field>
-                <mat-form-field appearance="fill">
-                  <mat-label>Priorité</mat-label>
-                  <mat-select [value]="complexOperators()[$index].precedence" (valueChange)="updateOperator($index, { precedence: $event })">
-                    <mat-option [value]="1">Normale (1)</mat-option>
-                    <mat-option [value]="2">Haute (2)</mat-option>
-                  </mat-select>
-                </mat-form-field>
-              </div>
-            }
           </div>
         }
+
+        <div>
+          <button mat-stroked-button type="button" (click)="addComplexTerm()">
+            <mat-icon>add</mat-icon>
+            Ajouter un terme
+          </button>
+        </div>
+
+        @if (complexTermError()) {
+          <div class="alert-text text-xs">{{ complexTermError() }}</div>
+        }
       </div>
+
+      <div class="border-layer rounded-md border p-3 flex flex-col gap-3">
+        <div class="text-[13px] font-semibold">Expression mathématique</div>
+
+        <div class="flex flex-wrap gap-2">
+          @for (alias of aliasList(); track alias) {
+            <button mat-stroked-button type="button" (click)="addToken({ kind: 'term', alias })">{{ alias }}</button>
+          }
+          <button mat-stroked-button type="button" (click)="addToken({ kind: 'operator', op: '+' })">+</button>
+          <button mat-stroked-button type="button" (click)="addToken({ kind: 'operator', op: '-' })">-</button>
+          <button mat-stroked-button type="button" (click)="addToken({ kind: 'operator', op: '*' })">*</button>
+          <button mat-stroked-button type="button" (click)="addToken({ kind: 'operator', op: '/' })">/</button>
+          <button mat-stroked-button type="button" (click)="addToken({ kind: 'paren', value: '(' })">(</button>
+          <button mat-stroked-button type="button" (click)="addToken({ kind: 'paren', value: ')' })">)</button>
+          <button mat-stroked-button type="button" (click)="removeLastToken()">Backspace</button>
+          <button mat-stroked-button type="button" (click)="clearExpression()">Effacer</button>
+        </div>
+
+        <div class="bg-layer-1 border-layer min-h-14 rounded-md border p-2">
+          <div class="text-[10px] text-muted mb-1">Aperçu</div>
+          <div class="font-mono text-sm">{{ expressionText() || '—' }}</div>
+        </div>
+
+        @if (expressionValidation().error) {
+          <div class="alert-text text-xs">{{ expressionValidation().error }}</div>
+        }
+      </div>
+    }
+
+    @if (formError()) {
+      <div class="alert-text text-xs">{{ formError() }}</div>
     }
   </form>
 </mat-dialog-content>
 
-<mat-dialog-actions align="center" class="bg-layer-3 light-text pb-3">
+<mat-dialog-actions align="center" class="bg-layer-3 light-text stats-dialog-actions">
   <button mat-stroked-button type="button" (click)="close()">Annuler</button>
   <button mat-flat-button color="primary" type="button" (click)="save()" [disabled]="!canSave()">
     {{ isEdit ? 'Mettre à jour' : 'Créer' }}

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
@@ -1,0 +1,135 @@
+<h2 mat-dialog-title class="bg-layer-3 light-text m-0 text-center">
+  {{ isEdit ? 'Éditer un Stat' : 'Créer un Stat' }}
+</h2>
+
+<mat-dialog-content class="bg-layer-3 light-text pt-3">
+  <form [formGroup]="form" class="flex flex-col gap-4">
+    <div class="grid grid-cols-[repeat(auto-fit,minmax(160px,1fr))] gap-3">
+      <mat-form-field appearance="fill">
+        <mat-label>ID</mat-label>
+        <input matInput formControlName="id" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Nom</mat-label>
+        <input matInput formControlName="name" />
+      </mat-form-field>
+    </div>
+
+    <div class="flex items-center gap-3">
+      <label for="stat-color" class="text-xs font-semibold">Couleur</label>
+      <input id="stat-color" type="color" formControlName="colorHex" class="timeline-color-input" />
+    </div>
+
+    <mat-radio-group class="flex justify-center gap-2" [formControl]="modeControl">
+      <mat-radio-button value="simple">Recherche simple</mat-radio-button>
+      <mat-radio-button value="complex">Recherche complexe</mat-radio-button>
+    </mat-radio-group>
+
+    @if (modeControl.value === 'simple') {
+      <div class="border-layer rounded-md border p-3">
+        <div class="text-[13px] font-semibold mb-2">Requête simple</div>
+        <div class="grid grid-cols-1 gap-3 md:grid-cols-2">
+          <mat-form-field appearance="fill">
+            <mat-label>Events ciblés</mat-label>
+            <mat-select [value]="simpleEventIds()" (valueChange)="simpleEventIds.set($event)" multiple>
+              @for (event of availableEvents(); track event.id) {
+                <mat-option [value]="event.id">{{ event.id }} · {{ event.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>Labels filtres (all)</mat-label>
+            <mat-select [value]="simpleLabelIds()" (valueChange)="simpleLabelIds.set($event)" multiple>
+              @for (label of availableLabels(); track label.id) {
+                <mat-option [value]="label.id">{{ label.id }} · {{ label.name }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </div>
+    } @else {
+      <div class="border-layer rounded-md border p-3 flex flex-col gap-3">
+        <div class="flex items-center justify-between">
+          <div class="text-[13px] font-semibold">Expression complexe</div>
+          <button mat-stroked-button type="button" (click)="addComplexTerm()">
+            <mat-icon>add</mat-icon>
+            Ajouter un terme
+          </button>
+        </div>
+
+        @for (term of complexTerms(); track $index) {
+          <div class="border-layer rounded-md border p-2">
+            <div class="flex items-center justify-between mb-2">
+              <div class="text-[12px] font-semibold">Opérande {{ $index + 1 }}</div>
+              <button mat-icon-button type="button" [disabled]="complexTerms().length <= 2" (click)="removeComplexTerm($index)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </div>
+
+            <div class="grid gap-2 md:grid-cols-3">
+              <mat-form-field appearance="fill">
+                <mat-label>Type</mat-label>
+                <mat-select [value]="term.kind" (valueChange)="updateTerm($index, { kind: $event })">
+                  <mat-option value="query">Requête</mat-option>
+                  <mat-option value="constant">Constante</mat-option>
+                </mat-select>
+              </mat-form-field>
+
+              @if (term.kind === 'constant') {
+                <mat-form-field appearance="fill" class="md:col-span-2">
+                  <mat-label>Valeur</mat-label>
+                  <input matInput type="number" [value]="term.constantValue" (input)="updateTerm($index, { constantValue: +$any($event.target).value })" />
+                </mat-form-field>
+              } @else {
+                <mat-form-field appearance="fill">
+                  <mat-label>Events</mat-label>
+                  <mat-select [value]="term.eventIds" (valueChange)="updateTerm($index, { eventIds: $event })" multiple>
+                    @for (event of availableEvents(); track event.id) {
+                      <mat-option [value]="event.id">{{ event.id }} · {{ event.name }}</mat-option>
+                    }
+                  </mat-select>
+                </mat-form-field>
+                <mat-form-field appearance="fill" class="md:col-span-2">
+                  <mat-label>Labels (all)</mat-label>
+                  <mat-select [value]="term.labelIds" (valueChange)="updateTerm($index, { labelIds: $event })" multiple>
+                    @for (label of availableLabels(); track label.id) {
+                      <mat-option [value]="label.id">{{ label.id }} · {{ label.name }}</mat-option>
+                    }
+                  </mat-select>
+                </mat-form-field>
+              }
+            </div>
+
+            @if ($index < complexOperators().length) {
+              <div class="mt-3 grid gap-2 md:grid-cols-2">
+                <mat-form-field appearance="fill">
+                  <mat-label>Opérateur</mat-label>
+                  <mat-select [value]="complexOperators()[$index].op" (valueChange)="updateOperator($index, { op: $event })">
+                    <mat-option value="+">+</mat-option>
+                    <mat-option value="-">-</mat-option>
+                    <mat-option value="*">*</mat-option>
+                    <mat-option value="/">/</mat-option>
+                  </mat-select>
+                </mat-form-field>
+                <mat-form-field appearance="fill">
+                  <mat-label>Priorité</mat-label>
+                  <mat-select [value]="complexOperators()[$index].precedence" (valueChange)="updateOperator($index, { precedence: $event })">
+                    <mat-option [value]="1">Normale (1)</mat-option>
+                    <mat-option [value]="2">Haute (2)</mat-option>
+                  </mat-select>
+                </mat-form-field>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="center" class="bg-layer-3 light-text pb-3">
+  <button mat-stroked-button type="button" (click)="close()">Annuler</button>
+  <button mat-flat-button color="primary" type="button" (click)="save()" [disabled]="!canSave()">
+    {{ isEdit ? 'Mettre à jour' : 'Créer' }}
+  </button>
+</mat-dialog-actions>

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
@@ -17,16 +17,10 @@
 
     <div class="border-layer rounded-md border p-3">
       <div class="mb-2 text-[13px] font-semibold">Couleur du bouton</div>
-      <div class="grid grid-cols-1 gap-3 md:grid-cols-[auto_1fr] md:items-center">
+      <div class="flex items-center gap-3">
         <input id="stat-color" type="color" formControlName="colorHex" class="timeline-color-input" />
-
-        <div class="flex flex-wrap items-center gap-3">
-          <div class="h-8 w-8 rounded border border-layer" [style.background]="colorPreview()"></div>
-          <div class="rounded-md border border-layer px-3 py-2 text-xs" [style.background]="colorPreview()" [style.color]="'#fff'">
-            Aperçu bouton stats
-          </div>
-          <span class="text-xs text-muted">{{ colorPreview() }}</span>
-        </div>
+        <div class="h-8 w-8 rounded border border-layer" [style.background]="colorPreview()"></div>
+        <span class="text-xs text-muted">{{ colorPreview() }}</span>
       </div>
       @if (colorError()) {
         <div class="alert-text mt-2 text-xs">{{ colorError() }}</div>
@@ -51,7 +45,7 @@
             </mat-select>
           </mat-form-field>
           <mat-form-field appearance="fill">
-            <mat-label>Labels filtres (all)</mat-label>
+            <mat-label>Labels filtres</mat-label>
             <mat-select [value]="simpleLabelIds()" (valueChange)="simpleLabelIds.set($event)" multiple>
               @for (label of availableLabels(); track label.id) {
                 <mat-option [value]="label.id">{{ label.id }} · {{ label.name }}</mat-option>
@@ -59,77 +53,36 @@
             </mat-select>
           </mat-form-field>
         </div>
+
+        @if (selectedSimpleLabels().length) {
+          <div class="mt-2 grid gap-2 md:grid-cols-2">
+            @for (label of selectedSimpleLabels(); track label!.id) {
+              <div class="border-layer flex items-center justify-between rounded-md border p-2">
+                <span class="text-xs">{{ label!.name }}</span>
+                <input
+                  type="color"
+                  class="timeline-color-input"
+                  [value]="simpleLabelColorById()[label!.id] || '#1f4b73'"
+                  (input)="updateSimpleLabelColor(label!.id, $any($event.target).value)"
+                />
+              </div>
+            }
+          </div>
+        }
+
         @if (simpleError()) {
-          <div class="alert-text text-xs">{{ simpleError() }}</div>
+          <div class="alert-text mt-2 text-xs">{{ simpleError() }}</div>
         }
       </div>
     } @else {
       <div class="border-layer rounded-md border p-3 flex flex-col gap-3">
-        <div class="text-[13px] font-semibold">Termes disponibles</div>
-
-        @for (term of complexTerms(); track $index) {
-          <div class="border-layer rounded-md border p-2">
-            <div class="flex items-center justify-between mb-2">
-              <div class="text-[12px] font-semibold">{{ aliasList()[$index] }} = {{ term.kind === 'query' ? 'Requête' : 'Constante' }}</div>
-              <button mat-icon-button type="button" [disabled]="complexTerms().length <= 1" (click)="removeComplexTerm($index)">
-                <mat-icon>delete</mat-icon>
-              </button>
-            </div>
-
-            <div class="grid gap-2 md:grid-cols-3">
-              <mat-form-field appearance="fill">
-                <mat-label>Type</mat-label>
-                <mat-select [value]="term.kind" (valueChange)="updateTerm($index, { kind: $event })">
-                  <mat-option value="query">Requête</mat-option>
-                  <mat-option value="constant">Constante</mat-option>
-                </mat-select>
-              </mat-form-field>
-
-              @if (term.kind === 'constant') {
-                <mat-form-field appearance="fill" class="md:col-span-2">
-                  <mat-label>Valeur</mat-label>
-                  <input matInput type="number" [value]="term.constantValue" (input)="updateTerm($index, { constantValue: +$any($event.target).value })" />
-                </mat-form-field>
-              } @else {
-                <mat-form-field appearance="fill">
-                  <mat-label>Events *</mat-label>
-                  <mat-select [value]="term.eventIds" (valueChange)="updateTerm($index, { eventIds: $event })" multiple>
-                    @for (event of availableEvents(); track event.id) {
-                      <mat-option [value]="event.id">{{ event.id }} · {{ event.name }}</mat-option>
-                    }
-                  </mat-select>
-                </mat-form-field>
-                <mat-form-field appearance="fill" class="md:col-span-2">
-                  <mat-label>Labels (all)</mat-label>
-                  <mat-select [value]="term.labelIds" (valueChange)="updateTerm($index, { labelIds: $event })" multiple>
-                    @for (label of availableLabels(); track label.id) {
-                      <mat-option [value]="label.id">{{ label.id }} · {{ label.name }}</mat-option>
-                    }
-                  </mat-select>
-                </mat-form-field>
-              }
-            </div>
-          </div>
-        }
-
-        <div>
-          <button mat-stroked-button type="button" (click)="addComplexTerm()">
-            <mat-icon>add</mat-icon>
-            Ajouter un terme
-          </button>
-        </div>
-
-        @if (complexTermError()) {
-          <div class="alert-text text-xs">{{ complexTermError() }}</div>
-        }
-      </div>
-
-      <div class="border-layer rounded-md border p-3 flex flex-col gap-3">
         <div class="text-[13px] font-semibold">Expression mathématique</div>
 
         <div class="flex flex-wrap gap-2">
-          @for (alias of aliasList(); track alias) {
-            <button mat-stroked-button type="button" (click)="addToken({ kind: 'term', alias })">{{ alias }}</button>
+          @for (term of complexTerms(); track term.id) {
+            <button mat-stroked-button type="button" (click)="addToken({ kind: 'term', termId: term.id })">
+              {{ term.displayName || 'Sans nom' }}
+            </button>
           }
           <button mat-stroked-button type="button" (click)="addToken({ kind: 'operator', op: '+' })">+</button>
           <button mat-stroked-button type="button" (click)="addToken({ kind: 'operator', op: '-' })">-</button>
@@ -150,10 +103,89 @@
           <div class="alert-text text-xs">{{ expressionValidation().error }}</div>
         }
       </div>
+
+      <div class="border-layer rounded-md border p-3 flex flex-col gap-3">
+        <div class="text-[13px] font-semibold">Termes disponibles</div>
+
+        @for (term of complexTerms(); track term.id) {
+          <div class="border-layer rounded-md border p-2 flex flex-col gap-2">
+            <div class="flex items-center justify-between">
+              <mat-form-field appearance="fill" class="flex-1">
+                <mat-label>Nom du terme</mat-label>
+                <input matInput [value]="term.displayName" (input)="updateTermDisplayName(term.id, $any($event.target).value)" />
+              </mat-form-field>
+              <button mat-icon-button type="button" [disabled]="complexTerms().length <= 1" (click)="removeComplexTerm(term.id)">
+                <mat-icon>delete</mat-icon>
+              </button>
+            </div>
+
+            <div class="grid gap-2 md:grid-cols-3">
+              <mat-form-field appearance="fill">
+                <mat-label>Type</mat-label>
+                <mat-select [value]="term.kind" (valueChange)="updateTermKind(term.id, $event)">
+                  <mat-option value="query">Requête</mat-option>
+                  <mat-option value="constant">Constante</mat-option>
+                </mat-select>
+              </mat-form-field>
+
+              @if (term.kind === 'constant') {
+                <mat-form-field appearance="fill" class="md:col-span-2">
+                  <mat-label>Valeur</mat-label>
+                  <input matInput type="number" [value]="term.constantValue" (input)="updateTermConstantValue(term.id, +$any($event.target).value)" />
+                </mat-form-field>
+              } @else {
+                <mat-form-field appearance="fill">
+                  <mat-label>Events *</mat-label>
+                  <mat-select [value]="term.eventIds" (valueChange)="updateTermEventIds(term.id, $event)" multiple>
+                    @for (event of availableEvents(); track event.id) {
+                      <mat-option [value]="event.id">{{ event.id }} · {{ event.name }}</mat-option>
+                    }
+                  </mat-select>
+                </mat-form-field>
+                <mat-form-field appearance="fill" class="md:col-span-2">
+                  <mat-label>Labels</mat-label>
+                  <mat-select [value]="term.labelIds" (valueChange)="updateTermLabelIds(term.id, $event)" multiple>
+                    @for (label of availableLabels(); track label.id) {
+                      <mat-option [value]="label.id">{{ label.id }} · {{ label.name }}</mat-option>
+                    }
+                  </mat-select>
+                </mat-form-field>
+              }
+            </div>
+
+            @if (term.kind === 'query' && getTermSelectedLabels(term).length) {
+              <div class="grid gap-2 md:grid-cols-2">
+                @for (label of getTermSelectedLabels(term); track label!.id) {
+                  <div class="border-layer flex items-center justify-between rounded-md border p-2">
+                    <span class="text-xs">{{ label!.name }}</span>
+                    <input
+                      type="color"
+                      class="timeline-color-input"
+                      [value]="term.labelColorById[label!.id] || '#1f4b73'"
+                      (input)="updateTermLabelColor(term.id, label!.id, $any($event.target).value)"
+                    />
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        }
+
+        <div>
+          <button mat-stroked-button type="button" (click)="addComplexTerm()">
+            <mat-icon>add</mat-icon>
+            Ajouter un terme
+          </button>
+        </div>
+
+        @if (complexTermError()) {
+          <div class="alert-text text-xs">{{ complexTermError() }}</div>
+        }
+      </div>
     }
 
-    @if (formError()) {
-      <div class="alert-text text-xs">{{ formError() }}</div>
+    @if (idNameError()) {
+      <div class="alert-text text-xs">{{ idNameError() }}</div>
     }
   </form>
 </mat-dialog-content>

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.scss
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.scss
@@ -1,0 +1,1 @@
+/* intentionally empty: styles through utility/theme classes */

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.scss
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.scss
@@ -1,1 +1,13 @@
-/* intentionally empty: styles through utility/theme classes */
+.stats-dialog-content {
+  max-height: min(72vh, 860px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-top: 0.75rem;
+}
+
+.stats-dialog-actions {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  padding-bottom: 0.75rem;
+}

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.spec.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.spec.ts
@@ -7,6 +7,7 @@ import { CreateStatBtnDialogComponent } from './create-stat-btn-dialog.component
 class MockSequencerPanelService {
   readonly btnList = signal([
     { id: 'evt-shot', name: 'Shot', type: 'event', eventProps: { kind: 'limited', preMs: 0, postMs: 0 } },
+    { id: 'evt-possession', name: 'Possession', type: 'event', eventProps: { kind: 'limited', preMs: 0, postMs: 0 } },
     { id: 'lbl-success', name: 'Success', type: 'label', labelProps: { mode: 'once' } },
   ] as const);
 
@@ -18,6 +19,7 @@ class MockSequencerPanelService {
 describe('CreateStatBtnDialogComponent', () => {
   let fixture: ComponentFixture<CreateStatBtnDialogComponent>;
   let component: CreateStatBtnDialogComponent;
+  let panelService: MockSequencerPanelService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -31,71 +33,123 @@ describe('CreateStatBtnDialogComponent', () => {
 
     fixture = TestBed.createComponent(CreateStatBtnDialogComponent);
     component = fixture.componentInstance;
+    panelService = TestBed.inject(SequencerPanelService) as unknown as MockSequencerPanelService;
     fixture.detectChanges();
   });
 
-  it('uses a valid default color', () => {
-    expect(component.form.controls.colorHex.value).toBe('#1f4b73');
-    expect(component.colorPreview()).toBe('#1f4b73');
-  });
-
-  it('reflects color changes in preview', () => {
-    component.form.controls.colorHex.setValue('#123456');
-    expect(component.colorPreview()).toBe('#123456');
-  });
-
-  it('enables create in simple mode when required fields are valid', () => {
+  it('recognizes valid id and name correctly', () => {
     component.form.controls.id.setValue('stat-1');
     component.form.controls.name.setValue('Stat 1');
+
+    expect(component.idNameError()).toBeNull();
+  });
+
+  it('hides id/name error when fields are filled', () => {
+    component.form.controls.id.markAsTouched();
+    component.form.controls.name.markAsTouched();
+    component.form.controls.id.setValue('stat-1');
+    component.form.controls.name.setValue('Stat 1');
+
+    expect(component.idNameError()).toBeNull();
+  });
+
+  it('enables create in simple mode when everything is valid', () => {
+    component.form.controls.id.setValue('stat-simple');
+    component.form.controls.name.setValue('Simple');
     component.simpleEventIds.set(['evt-shot']);
 
     expect(component.canSave()).toBeTrue();
   });
 
-  it('enables create in complex mode when expression is valid', () => {
+  it('enables create in complex mode when expression and terms are valid', () => {
     component.modeControl.setValue('complex');
-    component.form.controls.id.setValue('stat-2');
-    component.form.controls.name.setValue('Stat 2');
+    component.form.controls.id.setValue('stat-complex');
+    component.form.controls.name.setValue('Complex');
 
-    component.complexTerms.set([
-      { kind: 'query', constantValue: 0, eventIds: ['evt-shot'], labelIds: [] },
-      { kind: 'constant', constantValue: 2, eventIds: [], labelIds: [] },
-    ]);
+    const terms = component.complexTerms();
+    component.updateTermDisplayName(terms[0].id, 'Tirs marqués');
+    component.updateTermEventIds(terms[0].id, ['evt-shot']);
+    component.updateTermDisplayName(terms[1].id, 'Possessions');
+    component.updateTermKind(terms[1].id, 'query');
+    component.updateTermEventIds(terms[1].id, ['evt-possession']);
+
     component.clearExpression();
-    component.addToken({ kind: 'paren', value: '(' });
-    component.addToken({ kind: 'term', alias: 'A' });
-    component.addToken({ kind: 'operator', op: '+' });
-    component.addToken({ kind: 'term', alias: 'B' });
-    component.addToken({ kind: 'paren', value: ')' });
+    component.addToken({ kind: 'term', termId: terms[0].id });
     component.addToken({ kind: 'operator', op: '/' });
-    component.addToken({ kind: 'term', alias: 'B' });
+    component.addToken({ kind: 'term', termId: terms[1].id });
 
     expect(component.expressionValidation().ok).toBeTrue();
     expect(component.canSave()).toBeTrue();
   });
 
-  it('disables create when expression is incomplete or invalid', () => {
+  it('persists displayName for complex terms in JSON payload', () => {
     component.modeControl.setValue('complex');
-    component.form.controls.id.setValue('stat-3');
-    component.form.controls.name.setValue('Stat 3');
-    component.clearExpression();
-    component.addToken({ kind: 'term', alias: 'A' });
-    component.addToken({ kind: 'operator', op: '+' });
+    component.form.controls.id.setValue('stat-complex');
+    component.form.controls.name.setValue('Complex');
 
-    expect(component.expressionValidation().ok).toBeFalse();
-    expect(component.canSave()).toBeFalse();
+    const terms = component.complexTerms();
+    component.updateTermDisplayName(terms[0].id, 'Tirs marqués');
+    component.updateTermEventIds(terms[0].id, ['evt-shot']);
+
+    component.updateTermDisplayName(terms[1].id, 'Constante deux');
+    component.updateTermKind(terms[1].id, 'constant');
+    component.updateTermConstantValue(terms[1].id, 2);
+
+    component.clearExpression();
+    component.addToken({ kind: 'term', termId: terms[0].id });
+    component.addToken({ kind: 'operator', op: '/' });
+    component.addToken({ kind: 'term', termId: terms[1].id });
+
+    component.save();
+
+    const saved = panelService.addStatBtn.calls.mostRecent().args[0];
+    expect(saved.stat.mode).toBe('complex');
+    if (saved.stat.mode === 'complex') {
+      expect(saved.stat.editor?.terms[0].displayName).toBe('Tirs marqués');
+    }
   });
 
-  it('validates parenthesis balance', () => {
+  it('loads renamed terms when reopening in edit mode', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [CreateStatBtnDialogComponent],
+      providers: [
+        { provide: SequencerPanelService, useClass: MockSequencerPanelService },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            mode: 'edit',
+            btn: {
+              id: 'stat-edit',
+              name: 'Edit',
+              type: 'stat',
+              stat: {
+                mode: 'complex',
+                expression: { kind: 'constant', value: 1 },
+                editor: {
+                  terms: [
+                    { id: 'term_1', displayName: 'Possessions', kind: 'query', query: { eventIds: ['evt-possession'], labelIds: [], metric: 'count', labelMatch: 'all' } },
+                  ],
+                  tokens: [{ kind: 'term', termId: 'term_1' }],
+                },
+              },
+            },
+          },
+        },
+        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+      ],
+    }).compileComponents();
+
+    const editFixture = TestBed.createComponent(CreateStatBtnDialogComponent);
+    const editComponent = editFixture.componentInstance;
+    expect(editComponent.complexTerms()[0].displayName).toBe('Possessions');
+  });
+
+  it('renders expression section before terms section in complex mode', () => {
     component.modeControl.setValue('complex');
-    component.form.controls.id.setValue('stat-4');
-    component.form.controls.name.setValue('Stat 4');
+    fixture.detectChanges();
 
-    component.clearExpression();
-    component.addToken({ kind: 'paren', value: '(' });
-    component.addToken({ kind: 'term', alias: 'A' });
-
-    expect(component.expressionValidation().ok).toBeFalse();
-    expect(component.expressionValidation().error).toContain('incomplète');
+    const content = fixture.nativeElement.textContent as string;
+    expect(content.indexOf('Expression mathématique')).toBeLessThan(content.indexOf('Termes disponibles'));
   });
 });

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.spec.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.spec.ts
@@ -1,0 +1,101 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { SequencerPanelService } from '../../../../../core/service/sequencer-panel.service';
+import { CreateStatBtnDialogComponent } from './create-stat-btn-dialog.component';
+
+class MockSequencerPanelService {
+  readonly btnList = signal([
+    { id: 'evt-shot', name: 'Shot', type: 'event', eventProps: { kind: 'limited', preMs: 0, postMs: 0 } },
+    { id: 'lbl-success', name: 'Success', type: 'label', labelProps: { mode: 'once' } },
+  ] as const);
+
+  isIdAvailable = jasmine.createSpy('isIdAvailable').and.returnValue(true);
+  addStatBtn = jasmine.createSpy('addStatBtn');
+  updateBtn = jasmine.createSpy('updateBtn');
+}
+
+describe('CreateStatBtnDialogComponent', () => {
+  let fixture: ComponentFixture<CreateStatBtnDialogComponent>;
+  let component: CreateStatBtnDialogComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CreateStatBtnDialogComponent],
+      providers: [
+        { provide: SequencerPanelService, useClass: MockSequencerPanelService },
+        { provide: MAT_DIALOG_DATA, useValue: { mode: 'create' } },
+        { provide: MatDialogRef, useValue: { close: jasmine.createSpy('close') } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateStatBtnDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('uses a valid default color', () => {
+    expect(component.form.controls.colorHex.value).toBe('#1f4b73');
+    expect(component.colorPreview()).toBe('#1f4b73');
+  });
+
+  it('reflects color changes in preview', () => {
+    component.form.controls.colorHex.setValue('#123456');
+    expect(component.colorPreview()).toBe('#123456');
+  });
+
+  it('enables create in simple mode when required fields are valid', () => {
+    component.form.controls.id.setValue('stat-1');
+    component.form.controls.name.setValue('Stat 1');
+    component.simpleEventIds.set(['evt-shot']);
+
+    expect(component.canSave()).toBeTrue();
+  });
+
+  it('enables create in complex mode when expression is valid', () => {
+    component.modeControl.setValue('complex');
+    component.form.controls.id.setValue('stat-2');
+    component.form.controls.name.setValue('Stat 2');
+
+    component.complexTerms.set([
+      { kind: 'query', constantValue: 0, eventIds: ['evt-shot'], labelIds: [] },
+      { kind: 'constant', constantValue: 2, eventIds: [], labelIds: [] },
+    ]);
+    component.clearExpression();
+    component.addToken({ kind: 'paren', value: '(' });
+    component.addToken({ kind: 'term', alias: 'A' });
+    component.addToken({ kind: 'operator', op: '+' });
+    component.addToken({ kind: 'term', alias: 'B' });
+    component.addToken({ kind: 'paren', value: ')' });
+    component.addToken({ kind: 'operator', op: '/' });
+    component.addToken({ kind: 'term', alias: 'B' });
+
+    expect(component.expressionValidation().ok).toBeTrue();
+    expect(component.canSave()).toBeTrue();
+  });
+
+  it('disables create when expression is incomplete or invalid', () => {
+    component.modeControl.setValue('complex');
+    component.form.controls.id.setValue('stat-3');
+    component.form.controls.name.setValue('Stat 3');
+    component.clearExpression();
+    component.addToken({ kind: 'term', alias: 'A' });
+    component.addToken({ kind: 'operator', op: '+' });
+
+    expect(component.expressionValidation().ok).toBeFalse();
+    expect(component.canSave()).toBeFalse();
+  });
+
+  it('validates parenthesis balance', () => {
+    component.modeControl.setValue('complex');
+    component.form.controls.id.setValue('stat-4');
+    component.form.controls.name.setValue('Stat 4');
+
+    component.clearExpression();
+    component.addToken({ kind: 'paren', value: '(' });
+    component.addToken({ kind: 'term', alias: 'A' });
+
+    expect(component.expressionValidation().ok).toBeFalse();
+    expect(component.expressionValidation().error).toContain('incomplète');
+  });
+});

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.spec.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.spec.ts
@@ -53,6 +53,45 @@ describe('CreateStatBtnDialogComponent', () => {
     expect(component.idNameError()).toBeNull();
   });
 
+
+  it('updates canSave reactively when id changes', () => {
+    component.form.controls.name.setValue('Simple');
+    component.simpleEventIds.set(['evt-shot']);
+    expect(component.canSave()).toBeFalse();
+
+    component.form.controls.id.setValue('stat-id');
+    expect(component.canSave()).toBeTrue();
+  });
+
+  it('updates canSave reactively when name changes', () => {
+    component.form.controls.id.setValue('stat-name');
+    component.simpleEventIds.set(['evt-shot']);
+    expect(component.canSave()).toBeFalse();
+
+    component.form.controls.name.setValue('Nom');
+    expect(component.canSave()).toBeTrue();
+  });
+
+  it('updates canSave reactively when color changes', () => {
+    component.form.controls.id.setValue('stat-color');
+    component.form.controls.name.setValue('Color');
+    component.simpleEventIds.set(['evt-shot']);
+
+    component.form.controls.colorHex.setValue('invalid');
+    expect(component.canSave()).toBeFalse();
+
+    component.form.controls.colorHex.setValue('#123456');
+    expect(component.canSave()).toBeTrue();
+  });
+
+  it('updates canSave when simple event selection changes', () => {
+    component.form.controls.id.setValue('stat-simple');
+    component.form.controls.name.setValue('Simple');
+    expect(component.canSave()).toBeFalse();
+
+    component.simpleEventIds.set(['evt-shot']);
+    expect(component.canSave()).toBeTrue();
+  });
   it('enables create in simple mode when everything is valid', () => {
     component.form.controls.id.setValue('stat-simple');
     component.form.controls.name.setValue('Simple');
@@ -82,6 +121,28 @@ describe('CreateStatBtnDialogComponent', () => {
     expect(component.canSave()).toBeTrue();
   });
 
+
+  it('updates canSave when complex terms/tokens change', () => {
+    component.modeControl.setValue('complex');
+    component.form.controls.id.setValue('stat-complex-tick');
+    component.form.controls.name.setValue('Complex tick');
+
+    const terms = component.complexTerms();
+    component.updateTermDisplayName(terms[0].id, 'Tirs');
+    component.updateTermEventIds(terms[0].id, ['evt-shot']);
+
+    component.updateTermDisplayName(terms[1].id, 'Possessions');
+    component.updateTermKind(terms[1].id, 'query');
+    component.updateTermEventIds(terms[1].id, ['evt-possession']);
+
+    expect(component.canSave()).toBeFalse();
+
+    component.addToken({ kind: 'term', termId: terms[0].id });
+    component.addToken({ kind: 'operator', op: '/' });
+    component.addToken({ kind: 'term', termId: terms[1].id });
+
+    expect(component.canSave()).toBeTrue();
+  });
   it('persists displayName for complex terms in JSON payload', () => {
     component.modeControl.setValue('complex');
     component.form.controls.id.setValue('stat-complex');
@@ -109,6 +170,19 @@ describe('CreateStatBtnDialogComponent', () => {
     }
   });
 
+
+  it('keeps non-regression on save for simple mode', () => {
+    component.form.controls.id.setValue('stat-save-simple');
+    component.form.controls.name.setValue('Simple save');
+    component.simpleEventIds.set(['evt-shot']);
+    component.simpleLabelIds.set(['lbl-success']);
+
+    component.save();
+
+    expect(panelService.addStatBtn).toHaveBeenCalled();
+    const payload = panelService.addStatBtn.calls.mostRecent().args[0];
+    expect(payload.stat.mode).toBe('simple');
+  });
   it('loads renamed terms when reopening in edit mode', async () => {
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
@@ -1,0 +1,306 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { SequencerPanelService } from '../../../../../core/service/sequencer-panel.service';
+import {
+  SequencerStatDefinition,
+  SequencerStatNode,
+  SequencerStatOperator,
+  StatBtn,
+} from '../../../../../interfaces/sequencer-btn.interface';
+
+interface StatTermForm {
+  kind: 'query' | 'constant';
+  constantValue: number;
+  eventIds: string[];
+  labelIds: string[];
+}
+
+interface ComplexOperatorForm {
+  op: SequencerStatOperator;
+  precedence: 1 | 2;
+}
+
+export interface StatBtnDialogData {
+  mode: 'create' | 'edit';
+  btn?: StatBtn;
+}
+
+@Component({
+  selector: 'app-create-stat-btn-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatRadioModule,
+    MatSelectModule,
+    MatIconModule,
+  ],
+  templateUrl: './create-stat-btn-dialog.component.html',
+  styleUrl: './create-stat-btn-dialog.component.scss',
+})
+export class CreateStatBtnDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<CreateStatBtnDialogComponent>);
+  readonly data = inject<StatBtnDialogData>(MAT_DIALOG_DATA);
+  private readonly panelService = inject(SequencerPanelService);
+
+  readonly isEdit = this.data.mode === 'edit';
+  readonly modeControl = new FormControl<'simple' | 'complex'>(this.data.btn?.stat.mode ?? 'simple', { nonNullable: true });
+
+  readonly form = new FormGroup({
+    id: new FormControl({ value: this.data.btn?.id ?? '', disabled: this.isEdit }, [Validators.required]),
+    name: new FormControl(this.data.btn?.name ?? '', [Validators.required]),
+    colorHex: new FormControl(this.data.btn?.colorHex ?? '#1f4b73', { nonNullable: true }),
+  });
+
+  readonly simpleEventIds = signal<string[]>(
+    this.data.btn?.stat.mode === 'simple' ? this.data.btn.stat.query.eventIds : [],
+  );
+  readonly simpleLabelIds = signal<string[]>(
+    this.data.btn?.stat.mode === 'simple' ? this.data.btn.stat.query.labelIds : [],
+  );
+
+  readonly complexTerms = signal<StatTermForm[]>(
+    this.data.btn?.stat.mode === 'complex'
+      ? this.flattenComplexExpression(this.data.btn.stat.expression).terms
+      : [this.buildEmptyQueryTerm(), this.buildEmptyConstantTerm()],
+  );
+
+  readonly complexOperators = signal<ComplexOperatorForm[]>(
+    this.data.btn?.stat.mode === 'complex'
+      ? this.flattenComplexExpression(this.data.btn.stat.expression).operators
+      : [{ op: '+', precedence: 1 }],
+  );
+
+  readonly availableEvents = computed(() => this.panelService.btnList().filter(btn => btn.type === 'event'));
+  readonly availableLabels = computed(() => this.panelService.btnList().filter(btn => btn.type === 'label'));
+
+  readonly canSave = computed(() => {
+    if (this.form.invalid) {
+      return false;
+    }
+
+    const id = (this.form.controls.id.value ?? '').trim();
+    if (!this.isEdit && !this.panelService.isIdAvailable(id)) {
+      return false;
+    }
+
+    if (this.modeControl.value === 'complex') {
+      const terms = this.complexTerms();
+      const operators = this.complexOperators();
+      return terms.length >= 2 && operators.length === terms.length - 1;
+    }
+
+    return true;
+  });
+
+  addComplexTerm() {
+    this.complexTerms.set([...this.complexTerms(), this.buildEmptyQueryTerm()]);
+    this.complexOperators.set([...this.complexOperators(), { op: '+', precedence: 1 }]);
+  }
+
+  removeComplexTerm(index: number) {
+    const terms = this.complexTerms();
+    if (terms.length <= 2) {
+      return;
+    }
+
+    const nextTerms = terms.filter((_, idx) => idx !== index);
+    const nextOps = [...this.complexOperators()];
+    const opToRemove = index === 0 ? 0 : index - 1;
+    nextOps.splice(opToRemove, 1);
+    this.complexTerms.set(nextTerms);
+    this.complexOperators.set(nextOps);
+  }
+
+  updateTerm(index: number, patch: Partial<StatTermForm>) {
+    const next = this.complexTerms().map((term, idx) => (idx === index ? { ...term, ...patch } : term));
+    this.complexTerms.set(next);
+  }
+
+  updateOperator(index: number, patch: Partial<ComplexOperatorForm>) {
+    const next = this.complexOperators().map((operator, idx) => (idx === index ? { ...operator, ...patch } : operator));
+    this.complexOperators.set(next);
+  }
+
+  save() {
+    if (!this.canSave()) {
+      return;
+    }
+
+    const id = (this.form.controls.id.value ?? '').trim();
+    const name = (this.form.controls.name.value ?? '').trim();
+    const colorHex = this.form.controls.colorHex.value;
+
+    const statDefinition = this.modeControl.value === 'simple'
+      ? this.buildSimpleDefinition(this.simpleEventIds(), this.simpleLabelIds())
+      : this.buildComplexDefinition();
+
+    if (!statDefinition) {
+      return;
+    }
+
+    if (this.isEdit) {
+      this.panelService.updateBtn(id, {
+        name,
+        colorHex,
+        stat: statDefinition,
+      });
+    } else {
+      this.panelService.addStatBtn({
+        id,
+        name,
+        colorHex,
+        stat: statDefinition,
+      });
+    }
+
+    this.dialogRef.close(true);
+  }
+
+  close() {
+    this.dialogRef.close(false);
+  }
+
+  private buildSimpleDefinition(eventIds: string[], labelIds: string[]): SequencerStatDefinition {
+    return {
+      mode: 'simple',
+      query: {
+        eventIds,
+        labelIds,
+        metric: 'count',
+        labelMatch: 'all',
+      },
+    };
+  }
+
+  private buildComplexDefinition(): SequencerStatDefinition | null {
+    const outputStack: SequencerStatNode[] = [];
+    const operatorStack: ComplexOperatorForm[] = [];
+    const terms = this.complexTerms();
+    const operators = this.complexOperators();
+
+    for (let i = 0; i < terms.length; i += 1) {
+      const termNode = this.termToNode(terms[i]);
+      if (!termNode) {
+        return null;
+      }
+      outputStack.push(termNode);
+
+      if (i < operators.length) {
+        const operator = operators[i];
+        while (operatorStack.length && operatorStack[operatorStack.length - 1].precedence >= operator.precedence) {
+          if (!reduceLastOperator(outputStack, operatorStack.pop() as ComplexOperatorForm)) {
+            return null;
+          }
+        }
+        operatorStack.push(operator);
+      }
+    }
+
+    while (operatorStack.length) {
+      if (!reduceLastOperator(outputStack, operatorStack.pop() as ComplexOperatorForm)) {
+        return null;
+      }
+    }
+
+    const expression = outputStack[0];
+    if (!expression) {
+      return null;
+    }
+
+    return {
+      mode: 'complex',
+      expression,
+    };
+  }
+
+  private termToNode(term: StatTermForm): SequencerStatNode | null {
+    if (term.kind === 'constant') {
+      if (!Number.isFinite(term.constantValue)) {
+        return null;
+      }
+      return { kind: 'constant', value: term.constantValue };
+    }
+
+    return {
+      kind: 'query',
+      query: {
+        eventIds: term.eventIds,
+        labelIds: term.labelIds,
+        metric: 'count',
+        labelMatch: 'all',
+      },
+    };
+  }
+
+  private flattenComplexExpression(root: SequencerStatNode): { terms: StatTermForm[]; operators: ComplexOperatorForm[] } {
+    const terms: StatTermForm[] = [];
+    const operators: ComplexOperatorForm[] = [];
+
+    const visit = (node: SequencerStatNode) => {
+      if (node.kind === 'group') {
+        visit(node.left);
+        operators.push({ op: node.op, precedence: getOperatorPrecedence(node.op) });
+        visit(node.right);
+        return;
+      }
+
+      if (node.kind === 'constant') {
+        terms.push({ kind: 'constant', constantValue: node.value, eventIds: [], labelIds: [] });
+        return;
+      }
+
+      terms.push({
+        kind: 'query',
+        constantValue: 0,
+        eventIds: [...node.query.eventIds],
+        labelIds: [...node.query.labelIds],
+      });
+    };
+
+    visit(root);
+
+    return { terms, operators };
+  }
+
+  private buildEmptyQueryTerm(): StatTermForm {
+    return { kind: 'query', constantValue: 0, eventIds: [], labelIds: [] };
+  }
+
+  private buildEmptyConstantTerm(): StatTermForm {
+    return { kind: 'constant', constantValue: 1, eventIds: [], labelIds: [] };
+  }
+}
+
+function reduceLastOperator(outputStack: SequencerStatNode[], operator: ComplexOperatorForm): boolean {
+  const right = outputStack.pop();
+  const left = outputStack.pop();
+  if (!left || !right) {
+    return false;
+  }
+
+  outputStack.push({
+    kind: 'group',
+    left,
+    op: operator.op,
+    right,
+  });
+
+  return true;
+}
+
+function getOperatorPrecedence(op: SequencerStatOperator): 1 | 2 {
+  return op === '+' || op === '-' ? 1 : 2;
+}

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, inject, signal } from '@angular/core';
-import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -11,22 +11,22 @@ import { MatSelectModule } from '@angular/material/select';
 import { SequencerPanelService } from '../../../../../core/service/sequencer-panel.service';
 import {
   SequencerStatDefinition,
+  SequencerStatEditorTerm,
+  SequencerStatExpressionToken,
   SequencerStatNode,
   SequencerStatOperator,
   StatBtn,
 } from '../../../../../interfaces/sequencer-btn.interface';
 
-interface StatTermForm {
+interface EditableStatTerm {
+  id: string;
+  displayName: string;
   kind: 'query' | 'constant';
   constantValue: number;
   eventIds: string[];
   labelIds: string[];
+  labelColorById: Record<string, string>;
 }
-
-type ExpressionToken =
-  | { kind: 'term'; alias: string }
-  | { kind: 'operator'; op: SequencerStatOperator }
-  | { kind: 'paren'; value: '(' | ')' };
 
 export interface StatBtnDialogData {
   mode: 'create' | 'edit';
@@ -56,12 +56,14 @@ export class CreateStatBtnDialogComponent {
   private readonly panelService = inject(SequencerPanelService);
 
   readonly isEdit = this.data.mode === 'edit';
+  readonly submitted = signal(false);
+
   readonly modeControl = new FormControl<'simple' | 'complex'>(this.data.btn?.stat.mode ?? 'simple', { nonNullable: true });
 
   readonly form = new FormGroup({
-    id: new FormControl({ value: this.data.btn?.id ?? '', disabled: this.isEdit }, [Validators.required]),
-    name: new FormControl(this.data.btn?.name ?? '', [Validators.required]),
-    colorHex: new FormControl(this.normalizeColor(this.data.btn?.colorHex), {
+    id: new FormControl(this.data.btn?.id ?? '', { nonNullable: true, validators: [Validators.required, trimmedRequiredValidator()] }),
+    name: new FormControl(this.data.btn?.name ?? '', { nonNullable: true, validators: [Validators.required, trimmedRequiredValidator()] }),
+    colorHex: new FormControl(normalizeColor(this.data.btn?.colorHex), {
       nonNullable: true,
       validators: [Validators.required, Validators.pattern(/^#[0-9a-fA-F]{6}$/)],
     }),
@@ -73,68 +75,75 @@ export class CreateStatBtnDialogComponent {
   readonly simpleLabelIds = signal<string[]>(
     this.data.btn?.stat.mode === 'simple' ? this.data.btn.stat.query.labelIds : [],
   );
-
-  private readonly initialComplex = this.data.btn?.stat.mode === 'complex'
-    ? this.extractTermsAndTokensFromAst(this.data.btn.stat.expression)
-    : null;
-
-  readonly complexTerms = signal<StatTermForm[]>(
-    this.initialComplex?.terms ?? [this.buildEmptyQueryTerm(), this.buildEmptyConstantTerm()],
+  readonly simpleLabelColorById = signal<Record<string, string>>(
+    this.data.btn?.stat.mode === 'simple' ? { ...(this.data.btn.stat.query.labelColorById ?? {}) } : {},
   );
 
-  readonly expressionTokens = signal<ExpressionToken[]>(
-    this.initialComplex?.tokens ?? [
-      { kind: 'term', alias: 'A' },
-      { kind: 'operator', op: '+' },
-      { kind: 'term', alias: 'B' },
-    ],
+  private readonly initialComplex = this.data.btn?.stat.mode === 'complex'
+    ? this.getInitialComplexEditorState(this.data.btn.stat)
+    : null;
+
+  readonly complexTerms = signal<EditableStatTerm[]>(
+    this.initialComplex?.terms ?? [this.createQueryTerm(), this.createConstantTerm()],
+  );
+  readonly expressionTokens = signal<SequencerStatExpressionToken[]>(
+    this.initialComplex?.tokens ?? [],
   );
 
   readonly availableEvents = computed(() => this.panelService.btnList().filter(btn => btn.type === 'event'));
   readonly availableLabels = computed(() => this.panelService.btnList().filter(btn => btn.type === 'label'));
-  readonly aliasList = computed(() => this.complexTerms().map((_, index) => indexToAlias(index)));
+  readonly selectedSimpleLabels = computed(() => this.simpleLabelIds().map(id => this.availableLabels().find(label => label.id === id)).filter(Boolean));
 
-  readonly expressionText = computed(() =>
-    this.expressionTokens()
-      .map(token => {
-        if (token.kind === 'term') {
-          return token.alias;
-        }
-        if (token.kind === 'operator') {
-          return token.op;
-        }
-        return token.value;
-      })
-      .join(' '),
-  );
+  readonly colorPreview = computed(() => normalizeColor(this.form.controls.colorHex.value));
+  readonly expressionText = computed(() => this.expressionTokens().map(token => this.tokenLabel(token)).join(' '));
 
-  readonly colorPreview = computed(() => this.normalizeColor(this.form.controls.colorHex.value));
+  readonly idNameError = computed(() => {
+    const show = this.submitted() || this.form.controls.id.touched || this.form.controls.name.touched;
+    if (!show) {
+      return null;
+    }
+
+    if (this.form.controls.id.invalid || this.form.controls.name.invalid) {
+      return 'ID et nom sont requis.';
+    }
+
+    return null;
+  });
+
   readonly colorError = computed(() => {
     const control = this.form.controls.colorHex;
-    if (!control.invalid || !control.touched) {
+    if (!(this.submitted() || control.touched) || !control.invalid) {
       return null;
     }
     return 'Couleur invalide (format #RRGGBB).';
   });
 
-  readonly simpleError = computed(() =>
-    this.modeControl.value === 'simple' && this.simpleEventIds().length === 0
-      ? 'Sélectionne au moins un event.'
-      : null,
-  );
+  readonly simpleError = computed(() => {
+    if (this.modeControl.value !== 'simple') {
+      return null;
+    }
+
+    return this.simpleEventIds().length > 0 ? null : 'Sélectionne au moins un event.';
+  });
 
   readonly complexTermError = computed(() => {
     if (this.modeControl.value !== 'complex') {
       return null;
     }
 
-    const invalid = this.complexTerms().some(term =>
-      term.kind === 'query'
-        ? term.eventIds.length === 0
-        : !Number.isFinite(term.constantValue),
-    );
+    const invalidTerm = this.complexTerms().some(term => {
+      if (!term.displayName.trim()) {
+        return true;
+      }
 
-    return invalid ? 'Chaque terme doit être défini (event requis pour une requête, constante numérique valide).' : null;
+      if (term.kind === 'query') {
+        return term.eventIds.length === 0;
+      }
+
+      return !Number.isFinite(term.constantValue);
+    });
+
+    return invalidTerm ? 'Chaque terme doit avoir un nom et une définition valide.' : null;
   });
 
   readonly expressionValidation = computed(() => {
@@ -142,17 +151,19 @@ export class CreateStatBtnDialogComponent {
       return { ok: true, error: null as string | null, node: null as SequencerStatNode | null };
     }
 
-    const termsMap = this.buildAliasTermMap();
-    return buildExpressionNode(this.expressionTokens(), termsMap);
+    return buildExpressionTree(this.expressionTokens(), this.complexTerms());
   });
 
-  readonly canSave = computed(() => {
-    if (this.form.invalid) {
-      return false;
-    }
+  readonly formError = computed(() =>
+    this.idNameError()
+    ?? this.colorError()
+    ?? this.simpleError()
+    ?? this.complexTermError()
+    ?? this.expressionValidation().error,
+  );
 
-    const id = (this.form.controls.id.value ?? '').trim();
-    if (!this.isEdit && !this.panelService.isIdAvailable(id)) {
+  readonly canSave = computed(() => {
+    if (this.form.invalid || this.idNameError() || this.colorError()) {
       return false;
     }
 
@@ -163,67 +174,22 @@ export class CreateStatBtnDialogComponent {
     return !this.complexTermError() && this.expressionValidation().ok;
   });
 
-  readonly formError = computed(() => {
-    if (this.form.controls.id.invalid || this.form.controls.name.invalid) {
-      return 'ID et nom sont requis.';
+  constructor() {
+    if (this.isEdit) {
+      this.form.controls.id.disable({ emitEvent: false });
     }
-
-    if (this.colorError()) {
-      return this.colorError();
-    }
-
-    if (this.simpleError()) {
-      return this.simpleError();
-    }
-
-    if (this.complexTermError()) {
-      return this.complexTermError();
-    }
-
-    return this.expressionValidation().error;
-  });
+  }
 
   addComplexTerm() {
-    this.complexTerms.set([...this.complexTerms(), this.buildEmptyQueryTerm()]);
+    this.complexTerms.set([...this.complexTerms(), this.createQueryTerm()]);
   }
 
-  removeComplexTerm(index: number) {
-    const terms = this.complexTerms();
-    if (terms.length <= 1) {
-      return;
-    }
-
-    const aliasToRemove = indexToAlias(index);
-    const nextTerms = terms.filter((_, idx) => idx !== index);
-    this.complexTerms.set(nextTerms);
-
-    const nextTokens = this.expressionTokens()
-      .map(token => {
-        if (token.kind !== 'term') {
-          return token;
-        }
-
-        if (token.alias === aliasToRemove) {
-          return null;
-        }
-
-        const oldIndex = aliasToIndex(token.alias);
-        if (oldIndex > index) {
-          return { kind: 'term', alias: indexToAlias(oldIndex - 1) } as ExpressionToken;
-        }
-        return token;
-      })
-      .filter((token): token is ExpressionToken => token !== null);
-
-    this.expressionTokens.set(nextTokens);
+  removeComplexTerm(termId: string) {
+    this.complexTerms.set(this.complexTerms().filter(term => term.id !== termId));
+    this.expressionTokens.set(this.expressionTokens().filter(token => token.kind !== 'term' || token.termId !== termId));
   }
 
-  updateTerm(index: number, patch: Partial<StatTermForm>) {
-    const next = this.complexTerms().map((term, idx) => (idx === index ? { ...term, ...patch } : term));
-    this.complexTerms.set(next);
-  }
-
-  addToken(token: ExpressionToken) {
+  addToken(token: SequencerStatExpressionToken) {
     this.expressionTokens.set([...this.expressionTokens(), token]);
   }
 
@@ -235,18 +201,56 @@ export class CreateStatBtnDialogComponent {
     this.expressionTokens.set([]);
   }
 
+
+  updateTermDisplayName(termId: string, displayName: string) {
+    this.patchTerm(termId, { displayName });
+  }
+
+  updateTermKind(termId: string, kind: 'query' | 'constant') {
+    this.patchTerm(termId, { kind });
+  }
+
+  updateTermConstantValue(termId: string, constantValue: number) {
+    this.patchTerm(termId, { constantValue });
+  }
+
+  updateTermEventIds(termId: string, eventIds: string[]) {
+    this.patchTerm(termId, { eventIds });
+  }
+
+  updateTermLabelIds(termId: string, labelIds: string[]) {
+    this.patchTerm(termId, { labelIds });
+  }
+  updateSimpleLabelColor(labelId: string, color: string) {
+    const normalized = normalizeColor(color);
+    this.simpleLabelColorById.set({
+      ...this.simpleLabelColorById(),
+      [labelId]: normalized,
+    });
+  }
+
+  updateTermLabelColor(termId: string, labelId: string, color: string) {
+    const normalized = normalizeColor(color);
+    this.complexTerms.set(this.complexTerms().map(term =>
+      term.id === termId
+        ? { ...term, labelColorById: { ...term.labelColorById, [labelId]: normalized } }
+        : term,
+    ));
+  }
+
   save() {
+    this.submitted.set(true);
     this.form.markAllAsTouched();
     if (!this.canSave()) {
       return;
     }
 
-    const id = (this.form.controls.id.value ?? '').trim();
-    const name = (this.form.controls.name.value ?? '').trim();
-    const colorHex = this.normalizeColor(this.form.controls.colorHex.value);
+    const id = this.form.controls.id.value.trim();
+    const name = this.form.controls.name.value.trim();
+    const colorHex = normalizeColor(this.form.controls.colorHex.value);
 
     const statDefinition = this.modeControl.value === 'simple'
-      ? this.buildSimpleDefinition(this.simpleEventIds(), this.simpleLabelIds())
+      ? this.buildSimpleDefinition()
       : this.buildComplexDefinition();
 
     if (!statDefinition) {
@@ -254,18 +258,9 @@ export class CreateStatBtnDialogComponent {
     }
 
     if (this.isEdit) {
-      this.panelService.updateBtn(id, {
-        name,
-        colorHex,
-        stat: statDefinition,
-      });
+      this.panelService.updateBtn(id, { name, colorHex, stat: statDefinition });
     } else {
-      this.panelService.addStatBtn({
-        id,
-        name,
-        colorHex,
-        stat: statDefinition,
-      });
+      this.panelService.addStatBtn({ id, name, colorHex, stat: statDefinition });
     }
 
     this.dialogRef.close(true);
@@ -275,12 +270,22 @@ export class CreateStatBtnDialogComponent {
     this.dialogRef.close(false);
   }
 
-  private buildSimpleDefinition(eventIds: string[], labelIds: string[]): SequencerStatDefinition {
+
+  private patchTerm(termId: string, patch: Partial<EditableStatTerm>) {
+    this.complexTerms.set(this.complexTerms().map(term => term.id === termId ? { ...term, ...patch } : term));
+  }
+  private buildSimpleDefinition(): SequencerStatDefinition {
+    const selectedLabels = new Set(this.simpleLabelIds());
+    const colorById = Object.fromEntries(
+      Object.entries(this.simpleLabelColorById()).filter(([labelId]) => selectedLabels.has(labelId)),
+    );
+
     return {
       mode: 'simple',
       query: {
-        eventIds,
-        labelIds,
+        eventIds: [...this.simpleEventIds()],
+        labelIds: [...this.simpleLabelIds()],
+        labelColorById: colorById,
         metric: 'count',
         labelMatch: 'all',
       },
@@ -288,86 +293,227 @@ export class CreateStatBtnDialogComponent {
   }
 
   private buildComplexDefinition(): SequencerStatDefinition | null {
-    const result = this.expressionValidation();
-    if (!result.ok || !result.node) {
+    const compiled = this.expressionValidation();
+    if (!compiled.ok || !compiled.node) {
       return null;
     }
 
+    const terms: SequencerStatEditorTerm[] = this.complexTerms().map(term =>
+      term.kind === 'query'
+        ? {
+            id: term.id,
+            displayName: term.displayName.trim(),
+            kind: 'query',
+            query: {
+              eventIds: [...term.eventIds],
+              labelIds: [...term.labelIds],
+              labelColorById: { ...term.labelColorById },
+              metric: 'count',
+              labelMatch: 'all',
+            },
+          }
+        : {
+            id: term.id,
+            displayName: term.displayName.trim(),
+            kind: 'constant',
+            constantValue: term.constantValue,
+          },
+    );
+
     return {
       mode: 'complex',
-      expression: result.node,
+      expression: compiled.node,
+      editor: {
+        terms,
+        tokens: [...this.expressionTokens()],
+      },
     };
   }
 
-  private buildAliasTermMap() {
-    const map = new Map<string, StatTermForm>();
-    this.complexTerms().forEach((term, index) => {
-      map.set(indexToAlias(index), term);
-    });
-    return map;
-  }
-
-  private extractTermsAndTokensFromAst(root: SequencerStatNode): { terms: StatTermForm[]; tokens: ExpressionToken[] } {
-    const terms: StatTermForm[] = [];
-    const tokens: ExpressionToken[] = [];
-
-    const visit = (node: SequencerStatNode) => {
-      if (node.kind === 'group') {
-        tokens.push({ kind: 'paren', value: '(' });
-        visit(node.left);
-        tokens.push({ kind: 'operator', op: node.op });
-        visit(node.right);
-        tokens.push({ kind: 'paren', value: ')' });
-        return;
-      }
-
-      if (node.kind === 'constant') {
-        const alias = indexToAlias(terms.length);
-        terms.push({ kind: 'constant', constantValue: node.value, eventIds: [], labelIds: [] });
-        tokens.push({ kind: 'term', alias });
-        return;
-      }
-
-      const alias = indexToAlias(terms.length);
-      terms.push({
-        kind: 'query',
-        constantValue: 0,
-        eventIds: [...node.query.eventIds],
-        labelIds: [...node.query.labelIds],
-      });
-      tokens.push({ kind: 'term', alias });
-    };
-
-    visit(root);
-
-    return { terms, tokens };
-  }
-
-  private buildEmptyQueryTerm(): StatTermForm {
-    return { kind: 'query', constantValue: 0, eventIds: [], labelIds: [] };
-  }
-
-  private buildEmptyConstantTerm(): StatTermForm {
-    return { kind: 'constant', constantValue: 1, eventIds: [], labelIds: [] };
-  }
-
-  private normalizeColor(value: string | null | undefined) {
-    if (value && /^#[0-9a-fA-F]{6}$/.test(value)) {
-      return value;
+  private getInitialComplexEditorState(statDefinition: Extract<SequencerStatDefinition, { mode: 'complex' }>) {
+    if (statDefinition.editor) {
+      return {
+        terms: statDefinition.editor.terms.map(term =>
+          term.kind === 'query'
+            ? {
+                id: term.id,
+                displayName: term.displayName,
+                kind: 'query' as const,
+                constantValue: 0,
+                eventIds: [...(term.query?.eventIds ?? [])],
+                labelIds: [...(term.query?.labelIds ?? [])],
+                labelColorById: { ...(term.query?.labelColorById ?? {}) },
+              }
+            : {
+                id: term.id,
+                displayName: term.displayName,
+                kind: 'constant' as const,
+                constantValue: term.constantValue ?? 0,
+                eventIds: [],
+                labelIds: [],
+                labelColorById: {},
+              },
+        ),
+        tokens: [...statDefinition.editor.tokens],
+      };
     }
-    return '#1f4b73';
+
+    return flattenAstForEditing(statDefinition.expression);
+  }
+
+  private createQueryTerm(): EditableStatTerm {
+    return {
+      id: `term_${cryptoRandom()}`,
+      displayName: 'Nouvelle requête',
+      kind: 'query',
+      constantValue: 0,
+      eventIds: [],
+      labelIds: [],
+      labelColorById: {},
+    };
+  }
+
+  private createConstantTerm(): EditableStatTerm {
+    return {
+      id: `term_${cryptoRandom()}`,
+      displayName: 'Constante',
+      kind: 'constant',
+      constantValue: 1,
+      eventIds: [],
+      labelIds: [],
+      labelColorById: {},
+    };
+  }
+
+  tokenLabel(token: SequencerStatExpressionToken): string {
+    if (token.kind === 'operator') {
+      return token.op;
+    }
+    if (token.kind === 'paren') {
+      return token.value;
+    }
+
+    const term = this.complexTerms().find(item => item.id === token.termId);
+    return term?.displayName || token.termId;
+  }
+
+  getTermSelectedLabels(term: EditableStatTerm) {
+    return term.labelIds.map(id => this.availableLabels().find(label => label.id === id)).filter(Boolean);
   }
 }
 
-function indexToAlias(index: number): string {
-  return String.fromCharCode(65 + index);
+function buildExpressionTree(tokens: SequencerStatExpressionToken[], terms: EditableStatTerm[]) {
+  if (!tokens.length) {
+    return { ok: false, error: 'L’expression est vide.', node: null as SequencerStatNode | null };
+  }
+
+  const termById = new Map(terms.map(term => [term.id, term]));
+  const operators: (SequencerStatOperator | '(')[] = [];
+  const nodes: SequencerStatNode[] = [];
+
+  const reduce = () => {
+    const op = operators.pop();
+    const right = nodes.pop();
+    const left = nodes.pop();
+    if (!op || op === '(' || !left || !right) {
+      return false;
+    }
+    if (op === '/' && right.kind === 'constant' && right.value === 0) {
+      return false;
+    }
+    nodes.push({ kind: 'group', left, op, right });
+    return true;
+  };
+
+  let expectOperand = true;
+  let openParens = 0;
+
+  for (const token of tokens) {
+    if (token.kind === 'term') {
+      if (!expectOperand) {
+        return { ok: false, error: 'Opérateur manquant entre deux termes.', node: null };
+      }
+      const term = termById.get(token.termId);
+      if (!term) {
+        return { ok: false, error: 'Un terme référencé est introuvable.', node: null };
+      }
+      const node = toNode(term);
+      if (!node) {
+        return { ok: false, error: `Le terme "${term.displayName}" est invalide.`, node: null };
+      }
+      nodes.push(node);
+      expectOperand = false;
+      continue;
+    }
+
+    if (token.kind === 'paren') {
+      if (token.value === '(') {
+        if (!expectOperand) {
+          return { ok: false, error: 'Parenthèse ouvrante mal placée.', node: null };
+        }
+        operators.push('(');
+        openParens += 1;
+        continue;
+      }
+
+      if (expectOperand || openParens <= 0) {
+        return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
+      }
+
+      while (operators.length && operators[operators.length - 1] !== '(') {
+        if (!reduce()) {
+          return { ok: false, error: 'Division statique par zéro détectée.', node: null };
+        }
+      }
+
+      operators.pop();
+      openParens -= 1;
+      expectOperand = false;
+      continue;
+    }
+
+    if (expectOperand) {
+      return { ok: false, error: 'Opérateur sans opérande.', node: null };
+    }
+
+    while (operators.length) {
+      const top = operators[operators.length - 1];
+      if (top === '(' || precedence(top) < precedence(token.op)) {
+        break;
+      }
+      if (!reduce()) {
+        return { ok: false, error: 'Division statique par zéro détectée.', node: null };
+      }
+    }
+
+    operators.push(token.op);
+    expectOperand = true;
+  }
+
+  if (expectOperand) {
+    return { ok: false, error: 'L’expression est incomplète.', node: null };
+  }
+
+  if (openParens !== 0) {
+    return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
+  }
+
+  while (operators.length) {
+    if (!reduce()) {
+      return { ok: false, error: 'Division statique par zéro détectée.', node: null };
+    }
+  }
+
+  return nodes.length === 1
+    ? { ok: true, error: null, node: nodes[0] }
+    : { ok: false, error: 'L’expression est invalide.', node: null };
 }
 
-function aliasToIndex(alias: string): number {
-  return alias.charCodeAt(0) - 65;
-}
+function toNode(term: EditableStatTerm): SequencerStatNode | null {
+  if (!term.displayName.trim()) {
+    return null;
+  }
 
-function termToNode(term: StatTermForm): SequencerStatNode | null {
   if (term.kind === 'constant') {
     if (!Number.isFinite(term.constantValue)) {
       return null;
@@ -382,129 +528,76 @@ function termToNode(term: StatTermForm): SequencerStatNode | null {
   return {
     kind: 'query',
     query: {
-      eventIds: term.eventIds,
-      labelIds: term.labelIds,
+      eventIds: [...term.eventIds],
+      labelIds: [...term.labelIds],
+      labelColorById: { ...term.labelColorById },
       metric: 'count',
       labelMatch: 'all',
     },
   };
 }
 
-function buildExpressionNode(tokens: ExpressionToken[], aliasToTerm: Map<string, StatTermForm>) {
-  if (!tokens.length) {
-    return { ok: false, error: 'L’expression est vide.', node: null };
-  }
+function flattenAstForEditing(root: SequencerStatNode): { terms: EditableStatTerm[]; tokens: SequencerStatExpressionToken[] } {
+  const terms: EditableStatTerm[] = [];
+  const tokens: SequencerStatExpressionToken[] = [];
 
-  const operators: (SequencerStatOperator | "(")[] = [];
-  const nodes: SequencerStatNode[] = [];
-
-  const reduce = () => {
-    const op = operators.pop();
-    const right = nodes.pop();
-    const left = nodes.pop();
-    if (!op || op === '(' || !left || !right) {
-      return false;
+  const visit = (node: SequencerStatNode) => {
+    if (node.kind === 'group') {
+      tokens.push({ kind: 'paren', value: '(' });
+      visit(node.left);
+      tokens.push({ kind: 'operator', op: node.op });
+      visit(node.right);
+      tokens.push({ kind: 'paren', value: ')' });
+      return;
     }
 
-    if (op === '/' && right.kind === 'constant' && right.value === 0) {
-      return false;
+    const termId = `term_${cryptoRandom()}`;
+
+    if (node.kind === 'constant') {
+      terms.push({
+        id: termId,
+        displayName: `Constante ${terms.length + 1}`,
+        kind: 'constant',
+        constantValue: node.value,
+        eventIds: [],
+        labelIds: [],
+        labelColorById: {},
+      });
+    } else {
+      terms.push({
+        id: termId,
+        displayName: `Requête ${terms.length + 1}`,
+        kind: 'query',
+        constantValue: 0,
+        eventIds: [...node.query.eventIds],
+        labelIds: [...node.query.labelIds],
+        labelColorById: { ...(node.query.labelColorById ?? {}) },
+      });
     }
 
-    nodes.push({ kind: 'group', left, op, right });
-    return true;
+    tokens.push({ kind: 'term', termId });
   };
 
-  let expectOperand = true;
-  let balance = 0;
-
-  for (const token of tokens) {
-    if (token.kind === 'term') {
-      if (!expectOperand) {
-        return { ok: false, error: 'Opérateur manquant entre deux termes.', node: null };
-      }
-      const term = aliasToTerm.get(token.alias);
-      if (!term) {
-        return { ok: false, error: `Terme ${token.alias} introuvable.`, node: null };
-      }
-      const node = termToNode(term);
-      if (!node) {
-        return { ok: false, error: `Terme ${token.alias} invalide.`, node: null };
-      }
-      nodes.push(node);
-      expectOperand = false;
-      continue;
-    }
-
-    if (token.kind === 'paren') {
-      if (token.value === '(') {
-        if (!expectOperand) {
-          return { ok: false, error: 'Parenthèse ouvrante mal placée.', node: null };
-        }
-        operators.push('(');
-        balance += 1;
-        continue;
-      }
-
-      if (expectOperand || balance <= 0) {
-        return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
-      }
-
-      while (operators.length && operators[operators.length - 1] !== '(') {
-        if (!reduce()) {
-          return { ok: false, error: 'Division statique par zéro détectée.', node: null };
-        }
-      }
-
-      if (operators.pop() !== '(') {
-        return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
-      }
-      balance -= 1;
-      expectOperand = false;
-      continue;
-    }
-
-    if (expectOperand) {
-      return { ok: false, error: 'Opérateur sans opérande.', node: null };
-    }
-
-    while (operators.length) {
-      const topOperator = operators[operators.length - 1];
-      if (topOperator === '(' || precedence(topOperator) < precedence(token.op)) {
-        break;
-      }
-      if (!reduce()) {
-        return { ok: false, error: 'Division statique par zéro détectée.', node: null };
-      }
-    }
-
-    operators.push(token.op);
-    expectOperand = true;
-  }
-
-  if (expectOperand || balance !== 0) {
-    return { ok: false, error: 'L’expression est incomplète.', node: null };
-  }
-
-  while (operators.length) {
-    const top = operators[operators.length - 1];
-    if (top === '(') {
-      return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
-    }
-    if (!reduce()) {
-      return { ok: false, error: 'Division statique par zéro détectée.', node: null };
-    }
-  }
-
-  if (nodes.length !== 1) {
-    return { ok: false, error: 'L’expression est invalide.', node: null };
-  }
-
-  return { ok: true, error: null, node: nodes[0] };
+  visit(root);
+  return { terms, tokens };
 }
 
 function precedence(op: SequencerStatOperator): number {
-  if (op === '+' || op === '-') {
-    return 1;
+  return op === '+' || op === '-' ? 1 : 2;
+}
+
+function trimmedRequiredValidator(): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null =>
+    `${control.value ?? ''}`.trim().length ? null : { trimmedRequired: true };
+}
+
+function normalizeColor(value: string | null | undefined): string {
+  if (value && /^#[0-9a-fA-F]{6}$/.test(value)) {
+    return value;
   }
-  return 2;
+  return '#1f4b73';
+}
+
+function cryptoRandom(): string {
+  return Math.random().toString(36).slice(2, 9);
 }

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
@@ -23,10 +23,10 @@ interface StatTermForm {
   labelIds: string[];
 }
 
-interface ComplexOperatorForm {
-  op: SequencerStatOperator;
-  precedence: 1 | 2;
-}
+type ExpressionToken =
+  | { kind: 'term'; alias: string }
+  | { kind: 'operator'; op: SequencerStatOperator }
+  | { kind: 'paren'; value: '(' | ')' };
 
 export interface StatBtnDialogData {
   mode: 'create' | 'edit';
@@ -61,7 +61,10 @@ export class CreateStatBtnDialogComponent {
   readonly form = new FormGroup({
     id: new FormControl({ value: this.data.btn?.id ?? '', disabled: this.isEdit }, [Validators.required]),
     name: new FormControl(this.data.btn?.name ?? '', [Validators.required]),
-    colorHex: new FormControl(this.data.btn?.colorHex ?? '#1f4b73', { nonNullable: true }),
+    colorHex: new FormControl(this.normalizeColor(this.data.btn?.colorHex), {
+      nonNullable: true,
+      validators: [Validators.required, Validators.pattern(/^#[0-9a-fA-F]{6}$/)],
+    }),
   });
 
   readonly simpleEventIds = signal<string[]>(
@@ -71,20 +74,77 @@ export class CreateStatBtnDialogComponent {
     this.data.btn?.stat.mode === 'simple' ? this.data.btn.stat.query.labelIds : [],
   );
 
+  private readonly initialComplex = this.data.btn?.stat.mode === 'complex'
+    ? this.extractTermsAndTokensFromAst(this.data.btn.stat.expression)
+    : null;
+
   readonly complexTerms = signal<StatTermForm[]>(
-    this.data.btn?.stat.mode === 'complex'
-      ? this.flattenComplexExpression(this.data.btn.stat.expression).terms
-      : [this.buildEmptyQueryTerm(), this.buildEmptyConstantTerm()],
+    this.initialComplex?.terms ?? [this.buildEmptyQueryTerm(), this.buildEmptyConstantTerm()],
   );
 
-  readonly complexOperators = signal<ComplexOperatorForm[]>(
-    this.data.btn?.stat.mode === 'complex'
-      ? this.flattenComplexExpression(this.data.btn.stat.expression).operators
-      : [{ op: '+', precedence: 1 }],
+  readonly expressionTokens = signal<ExpressionToken[]>(
+    this.initialComplex?.tokens ?? [
+      { kind: 'term', alias: 'A' },
+      { kind: 'operator', op: '+' },
+      { kind: 'term', alias: 'B' },
+    ],
   );
 
   readonly availableEvents = computed(() => this.panelService.btnList().filter(btn => btn.type === 'event'));
   readonly availableLabels = computed(() => this.panelService.btnList().filter(btn => btn.type === 'label'));
+  readonly aliasList = computed(() => this.complexTerms().map((_, index) => indexToAlias(index)));
+
+  readonly expressionText = computed(() =>
+    this.expressionTokens()
+      .map(token => {
+        if (token.kind === 'term') {
+          return token.alias;
+        }
+        if (token.kind === 'operator') {
+          return token.op;
+        }
+        return token.value;
+      })
+      .join(' '),
+  );
+
+  readonly colorPreview = computed(() => this.normalizeColor(this.form.controls.colorHex.value));
+  readonly colorError = computed(() => {
+    const control = this.form.controls.colorHex;
+    if (!control.invalid || !control.touched) {
+      return null;
+    }
+    return 'Couleur invalide (format #RRGGBB).';
+  });
+
+  readonly simpleError = computed(() =>
+    this.modeControl.value === 'simple' && this.simpleEventIds().length === 0
+      ? 'Sélectionne au moins un event.'
+      : null,
+  );
+
+  readonly complexTermError = computed(() => {
+    if (this.modeControl.value !== 'complex') {
+      return null;
+    }
+
+    const invalid = this.complexTerms().some(term =>
+      term.kind === 'query'
+        ? term.eventIds.length === 0
+        : !Number.isFinite(term.constantValue),
+    );
+
+    return invalid ? 'Chaque terme doit être défini (event requis pour une requête, constante numérique valide).' : null;
+  });
+
+  readonly expressionValidation = computed(() => {
+    if (this.modeControl.value !== 'complex') {
+      return { ok: true, error: null as string | null, node: null as SequencerStatNode | null };
+    }
+
+    const termsMap = this.buildAliasTermMap();
+    return buildExpressionNode(this.expressionTokens(), termsMap);
+  });
 
   readonly canSave = computed(() => {
     if (this.form.invalid) {
@@ -96,32 +156,66 @@ export class CreateStatBtnDialogComponent {
       return false;
     }
 
-    if (this.modeControl.value === 'complex') {
-      const terms = this.complexTerms();
-      const operators = this.complexOperators();
-      return terms.length >= 2 && operators.length === terms.length - 1;
+    if (this.modeControl.value === 'simple') {
+      return this.simpleEventIds().length > 0;
     }
 
-    return true;
+    return !this.complexTermError() && this.expressionValidation().ok;
+  });
+
+  readonly formError = computed(() => {
+    if (this.form.controls.id.invalid || this.form.controls.name.invalid) {
+      return 'ID et nom sont requis.';
+    }
+
+    if (this.colorError()) {
+      return this.colorError();
+    }
+
+    if (this.simpleError()) {
+      return this.simpleError();
+    }
+
+    if (this.complexTermError()) {
+      return this.complexTermError();
+    }
+
+    return this.expressionValidation().error;
   });
 
   addComplexTerm() {
     this.complexTerms.set([...this.complexTerms(), this.buildEmptyQueryTerm()]);
-    this.complexOperators.set([...this.complexOperators(), { op: '+', precedence: 1 }]);
   }
 
   removeComplexTerm(index: number) {
     const terms = this.complexTerms();
-    if (terms.length <= 2) {
+    if (terms.length <= 1) {
       return;
     }
 
+    const aliasToRemove = indexToAlias(index);
     const nextTerms = terms.filter((_, idx) => idx !== index);
-    const nextOps = [...this.complexOperators()];
-    const opToRemove = index === 0 ? 0 : index - 1;
-    nextOps.splice(opToRemove, 1);
     this.complexTerms.set(nextTerms);
-    this.complexOperators.set(nextOps);
+
+    const nextTokens = this.expressionTokens()
+      .map(token => {
+        if (token.kind !== 'term') {
+          return token;
+        }
+
+        if (token.alias === aliasToRemove) {
+          return null;
+        }
+
+        const oldIndex = aliasToIndex(token.alias);
+        if (oldIndex > index) {
+          return { kind: 'term', alias: indexToAlias(oldIndex - 1) } as ExpressionToken;
+        }
+        return token;
+      })
+      .filter((token): token is ExpressionToken => token !== null);
+
+    this.expressionTokens.set(nextTokens);
   }
 
   updateTerm(index: number, patch: Partial<StatTermForm>) {
@@ -129,19 +223,27 @@ export class CreateStatBtnDialogComponent {
     this.complexTerms.set(next);
   }
 
-  updateOperator(index: number, patch: Partial<ComplexOperatorForm>) {
-    const next = this.complexOperators().map((operator, idx) => (idx === index ? { ...operator, ...patch } : operator));
-    this.complexOperators.set(next);
+  addToken(token: ExpressionToken) {
+    this.expressionTokens.set([...this.expressionTokens(), token]);
+  }
+
+  removeLastToken() {
+    this.expressionTokens.set(this.expressionTokens().slice(0, -1));
+  }
+
+  clearExpression() {
+    this.expressionTokens.set([]);
   }
 
   save() {
+    this.form.markAllAsTouched();
     if (!this.canSave()) {
       return;
     }
 
     const id = (this.form.controls.id.value ?? '').trim();
     const name = (this.form.controls.name.value ?? '').trim();
-    const colorHex = this.form.controls.colorHex.value;
+    const colorHex = this.normalizeColor(this.form.controls.colorHex.value);
 
     const statDefinition = this.modeControl.value === 'simple'
       ? this.buildSimpleDefinition(this.simpleEventIds(), this.simpleLabelIds())
@@ -186,93 +288,59 @@ export class CreateStatBtnDialogComponent {
   }
 
   private buildComplexDefinition(): SequencerStatDefinition | null {
-    const outputStack: SequencerStatNode[] = [];
-    const operatorStack: ComplexOperatorForm[] = [];
-    const terms = this.complexTerms();
-    const operators = this.complexOperators();
-
-    for (let i = 0; i < terms.length; i += 1) {
-      const termNode = this.termToNode(terms[i]);
-      if (!termNode) {
-        return null;
-      }
-      outputStack.push(termNode);
-
-      if (i < operators.length) {
-        const operator = operators[i];
-        while (operatorStack.length && operatorStack[operatorStack.length - 1].precedence >= operator.precedence) {
-          if (!reduceLastOperator(outputStack, operatorStack.pop() as ComplexOperatorForm)) {
-            return null;
-          }
-        }
-        operatorStack.push(operator);
-      }
-    }
-
-    while (operatorStack.length) {
-      if (!reduceLastOperator(outputStack, operatorStack.pop() as ComplexOperatorForm)) {
-        return null;
-      }
-    }
-
-    const expression = outputStack[0];
-    if (!expression) {
+    const result = this.expressionValidation();
+    if (!result.ok || !result.node) {
       return null;
     }
 
     return {
       mode: 'complex',
-      expression,
+      expression: result.node,
     };
   }
 
-  private termToNode(term: StatTermForm): SequencerStatNode | null {
-    if (term.kind === 'constant') {
-      if (!Number.isFinite(term.constantValue)) {
-        return null;
-      }
-      return { kind: 'constant', value: term.constantValue };
-    }
-
-    return {
-      kind: 'query',
-      query: {
-        eventIds: term.eventIds,
-        labelIds: term.labelIds,
-        metric: 'count',
-        labelMatch: 'all',
-      },
-    };
+  private buildAliasTermMap() {
+    const map = new Map<string, StatTermForm>();
+    this.complexTerms().forEach((term, index) => {
+      map.set(indexToAlias(index), term);
+    });
+    return map;
   }
 
-  private flattenComplexExpression(root: SequencerStatNode): { terms: StatTermForm[]; operators: ComplexOperatorForm[] } {
+  private extractTermsAndTokensFromAst(root: SequencerStatNode): { terms: StatTermForm[]; tokens: ExpressionToken[] } {
     const terms: StatTermForm[] = [];
-    const operators: ComplexOperatorForm[] = [];
+    const tokens: ExpressionToken[] = [];
 
     const visit = (node: SequencerStatNode) => {
       if (node.kind === 'group') {
+        tokens.push({ kind: 'paren', value: '(' });
         visit(node.left);
-        operators.push({ op: node.op, precedence: getOperatorPrecedence(node.op) });
+        tokens.push({ kind: 'operator', op: node.op });
         visit(node.right);
+        tokens.push({ kind: 'paren', value: ')' });
         return;
       }
 
       if (node.kind === 'constant') {
+        const alias = indexToAlias(terms.length);
         terms.push({ kind: 'constant', constantValue: node.value, eventIds: [], labelIds: [] });
+        tokens.push({ kind: 'term', alias });
         return;
       }
 
+      const alias = indexToAlias(terms.length);
       terms.push({
         kind: 'query',
         constantValue: 0,
         eventIds: [...node.query.eventIds],
         labelIds: [...node.query.labelIds],
       });
+      tokens.push({ kind: 'term', alias });
     };
 
     visit(root);
 
-    return { terms, operators };
+    return { terms, tokens };
   }
 
   private buildEmptyQueryTerm(): StatTermForm {
@@ -282,25 +350,161 @@ export class CreateStatBtnDialogComponent {
   private buildEmptyConstantTerm(): StatTermForm {
     return { kind: 'constant', constantValue: 1, eventIds: [], labelIds: [] };
   }
+
+  private normalizeColor(value: string | null | undefined) {
+    if (value && /^#[0-9a-fA-F]{6}$/.test(value)) {
+      return value;
+    }
+    return '#1f4b73';
+  }
 }
 
-function reduceLastOperator(outputStack: SequencerStatNode[], operator: ComplexOperatorForm): boolean {
-  const right = outputStack.pop();
-  const left = outputStack.pop();
-  if (!left || !right) {
-    return false;
+function indexToAlias(index: number): string {
+  return String.fromCharCode(65 + index);
+}
+
+function aliasToIndex(alias: string): number {
+  return alias.charCodeAt(0) - 65;
+}
+
+function termToNode(term: StatTermForm): SequencerStatNode | null {
+  if (term.kind === 'constant') {
+    if (!Number.isFinite(term.constantValue)) {
+      return null;
+    }
+    return { kind: 'constant', value: term.constantValue };
   }
 
-  outputStack.push({
-    kind: 'group',
-    left,
-    op: operator.op,
-    right,
-  });
+  if (!term.eventIds.length) {
+    return null;
+  }
 
-  return true;
+  return {
+    kind: 'query',
+    query: {
+      eventIds: term.eventIds,
+      labelIds: term.labelIds,
+      metric: 'count',
+      labelMatch: 'all',
+    },
+  };
 }
 
-function getOperatorPrecedence(op: SequencerStatOperator): 1 | 2 {
-  return op === '+' || op === '-' ? 1 : 2;
+function buildExpressionNode(tokens: ExpressionToken[], aliasToTerm: Map<string, StatTermForm>) {
+  if (!tokens.length) {
+    return { ok: false, error: 'L’expression est vide.', node: null };
+  }
+
+  const operators: (SequencerStatOperator | "(")[] = [];
+  const nodes: SequencerStatNode[] = [];
+
+  const reduce = () => {
+    const op = operators.pop();
+    const right = nodes.pop();
+    const left = nodes.pop();
+    if (!op || op === '(' || !left || !right) {
+      return false;
+    }
+
+    if (op === '/' && right.kind === 'constant' && right.value === 0) {
+      return false;
+    }
+
+    nodes.push({ kind: 'group', left, op, right });
+    return true;
+  };
+
+  let expectOperand = true;
+  let balance = 0;
+
+  for (const token of tokens) {
+    if (token.kind === 'term') {
+      if (!expectOperand) {
+        return { ok: false, error: 'Opérateur manquant entre deux termes.', node: null };
+      }
+      const term = aliasToTerm.get(token.alias);
+      if (!term) {
+        return { ok: false, error: `Terme ${token.alias} introuvable.`, node: null };
+      }
+      const node = termToNode(term);
+      if (!node) {
+        return { ok: false, error: `Terme ${token.alias} invalide.`, node: null };
+      }
+      nodes.push(node);
+      expectOperand = false;
+      continue;
+    }
+
+    if (token.kind === 'paren') {
+      if (token.value === '(') {
+        if (!expectOperand) {
+          return { ok: false, error: 'Parenthèse ouvrante mal placée.', node: null };
+        }
+        operators.push('(');
+        balance += 1;
+        continue;
+      }
+
+      if (expectOperand || balance <= 0) {
+        return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
+      }
+
+      while (operators.length && operators[operators.length - 1] !== '(') {
+        if (!reduce()) {
+          return { ok: false, error: 'Division statique par zéro détectée.', node: null };
+        }
+      }
+
+      if (operators.pop() !== '(') {
+        return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
+      }
+      balance -= 1;
+      expectOperand = false;
+      continue;
+    }
+
+    if (expectOperand) {
+      return { ok: false, error: 'Opérateur sans opérande.', node: null };
+    }
+
+    while (operators.length) {
+      const topOperator = operators[operators.length - 1];
+      if (topOperator === '(' || precedence(topOperator) < precedence(token.op)) {
+        break;
+      }
+      if (!reduce()) {
+        return { ok: false, error: 'Division statique par zéro détectée.', node: null };
+      }
+    }
+
+    operators.push(token.op);
+    expectOperand = true;
+  }
+
+  if (expectOperand || balance !== 0) {
+    return { ok: false, error: 'L’expression est incomplète.', node: null };
+  }
+
+  while (operators.length) {
+    const top = operators[operators.length - 1];
+    if (top === '(') {
+      return { ok: false, error: 'Parenthèses non équilibrées.', node: null };
+    }
+    if (!reduce()) {
+      return { ok: false, error: 'Division statique par zéro détectée.', node: null };
+    }
+  }
+
+  if (nodes.length !== 1) {
+    return { ok: false, error: 'L’expression est invalide.', node: null };
+  }
+
+  return { ok: true, error: null, node: nodes[0] };
+}
+
+function precedence(op: SequencerStatOperator): number {
+  if (op === '+' || op === '-') {
+    return 1;
+  }
+  return 2;
 }

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { Component, computed, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
@@ -8,6 +9,8 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
+import { merge } from 'rxjs';
+import { startWith } from 'rxjs/operators';
 import { SequencerPanelService } from '../../../../../core/service/sequencer-panel.service';
 import {
   SequencerStatDefinition,
@@ -90,6 +93,19 @@ export class CreateStatBtnDialogComponent {
     this.initialComplex?.tokens ?? [],
   );
 
+
+  readonly modeValue = toSignal(this.modeControl.valueChanges.pipe(startWith(this.modeControl.value)), {
+    initialValue: this.modeControl.value,
+  });
+
+  private readonly formSync = toSignal(
+    merge(
+      this.form.valueChanges,
+      this.form.statusChanges,
+      this.modeControl.valueChanges,
+    ).pipe(startWith(null)),
+    { initialValue: null },
+  );
   readonly availableEvents = computed(() => this.panelService.btnList().filter(btn => btn.type === 'event'));
   readonly availableLabels = computed(() => this.panelService.btnList().filter(btn => btn.type === 'label'));
   readonly selectedSimpleLabels = computed(() => this.simpleLabelIds().map(id => this.availableLabels().find(label => label.id === id)).filter(Boolean));
@@ -98,6 +114,7 @@ export class CreateStatBtnDialogComponent {
   readonly expressionText = computed(() => this.expressionTokens().map(token => this.tokenLabel(token)).join(' '));
 
   readonly idNameError = computed(() => {
+    this.formSync();
     const show = this.submitted() || this.form.controls.id.touched || this.form.controls.name.touched;
     if (!show) {
       return null;
@@ -111,6 +128,7 @@ export class CreateStatBtnDialogComponent {
   });
 
   readonly colorError = computed(() => {
+    this.formSync();
     const control = this.form.controls.colorHex;
     if (!(this.submitted() || control.touched) || !control.invalid) {
       return null;
@@ -119,7 +137,8 @@ export class CreateStatBtnDialogComponent {
   });
 
   readonly simpleError = computed(() => {
-    if (this.modeControl.value !== 'simple') {
+    this.formSync();
+    if (this.modeValue() !== 'simple') {
       return null;
     }
 
@@ -127,7 +146,8 @@ export class CreateStatBtnDialogComponent {
   });
 
   readonly complexTermError = computed(() => {
-    if (this.modeControl.value !== 'complex') {
+    this.formSync();
+    if (this.modeValue() !== 'complex') {
       return null;
     }
 
@@ -147,27 +167,31 @@ export class CreateStatBtnDialogComponent {
   });
 
   readonly expressionValidation = computed(() => {
-    if (this.modeControl.value !== 'complex') {
+    this.formSync();
+    if (this.modeValue() !== 'complex') {
       return { ok: true, error: null as string | null, node: null as SequencerStatNode | null };
     }
 
     return buildExpressionTree(this.expressionTokens(), this.complexTerms());
   });
 
-  readonly formError = computed(() =>
-    this.idNameError()
+  readonly formError = computed(() => {
+    this.formSync();
+    return this.idNameError()
     ?? this.colorError()
     ?? this.simpleError()
     ?? this.complexTermError()
-    ?? this.expressionValidation().error,
-  );
+    ?? this.expressionValidation().error;
+  });
 
   readonly canSave = computed(() => {
+    this.formSync();
     if (this.form.invalid || this.idNameError() || this.colorError()) {
       return false;
     }
 
-    if (this.modeControl.value === 'simple') {
+    const mode = this.modeValue();
+    if (mode === 'simple') {
       return this.simpleEventIds().length > 0;
     }
 
@@ -249,7 +273,7 @@ export class CreateStatBtnDialogComponent {
     const name = this.form.controls.name.value.trim();
     const colorHex = normalizeColor(this.form.controls.colorHex.value);
 
-    const statDefinition = this.modeControl.value === 'simple'
+    const statDefinition = this.modeValue() === 'simple'
       ? this.buildSimpleDefinition()
       : this.buildComplexDefinition();
 

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.html
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.html
@@ -37,6 +37,10 @@
               title="Créer un label">
         <mat-icon aria-hidden="true">new_label</mat-icon>
       </button>
+      <button type="button" class="seq-btn-stat icon p-2" (click)="openStatDialog()" aria-label="Créer une stat"
+              title="Créer une stat">
+        <mat-icon aria-hidden="true">query_stats</mat-icon>
+      </button>
 
       <div class="flex">
         <button type="button" class="icon p-2" (click)="toggleRename()">

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.ts
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.ts
@@ -17,9 +17,10 @@ import { MatInputModule } from '@angular/material/input';
 import { SequencerPanelService } from '../../../core/service/sequencer-panel.service';
 import { SequencerRuntimeService } from '../../../core/service/sequencer-runtime.service';
 import { HotkeysService } from '../../../core/services/hotkeys.service';
-import { EventBtn, LabelBtn, SequencerBtn } from '../../../interfaces/sequencer-btn.interface';
+import { EventBtn, LabelBtn, SequencerBtn, StatBtn } from '../../../interfaces/sequencer-btn.interface';
 import { CreateEventBtnDialogComponent } from './createBtn/event/create-event-btn-dialog.component';
 import { CreateLabelBtnDialogComponent } from './createBtn/label/create-label-btn-dialog.component';
+import { CreateStatBtnDialogComponent } from './createBtn/stat/create-stat-btn-dialog.component';
 import { SequencerCanvasComponent } from './canvas/sequencer-canvas.component';
 
 @Component({
@@ -102,8 +103,16 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+
+  openStatDialog(btn?: StatBtn) {
+    this.dialog.open(CreateStatBtnDialogComponent, {
+      width: '70%',
+      data: { mode: btn ? 'edit' : 'create', btn },
+    });
+  }
+
   onBtnClick(btn: SequencerBtn) {
-    if (this.editMode()) {
+    if (this.editMode() || btn.type === 'stat') {
       return;
     }
     this.runtimeService.trigger(btn.id, 'click');
@@ -112,9 +121,15 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
   openEditDialog(btn: SequencerBtn) {
     if (btn.type === 'event') {
       this.openEventDialog(btn);
-    } else {
-      this.openLabelDialog(btn);
+      return;
     }
+
+    if (btn.type === 'label') {
+      this.openLabelDialog(btn);
+      return;
+    }
+
+    this.openStatDialog(btn);
   }
 
   deleteBtn(btn: SequencerBtn) {

--- a/src/app/core/service/sequencer-panel.service.spec.ts
+++ b/src/app/core/service/sequencer-panel.service.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { SequencerPanelService } from './sequencer-panel.service';
+
+describe('SequencerPanelService', () => {
+  let service: SequencerPanelService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [SequencerPanelService] });
+    service = TestBed.inject(SequencerPanelService);
+  });
+
+  it('creates a stat button', () => {
+    const created = service.addStatBtn({
+      id: 'stat-shots',
+      name: 'Tirs',
+      colorHex: '#000000',
+      stat: {
+        mode: 'simple',
+        query: { eventIds: ['evt_shot'], labelIds: [], metric: 'count', labelMatch: 'all' },
+      },
+    });
+
+    expect(created?.type).toBe('stat');
+    expect(service.getBtnById('stat-shots')?.type).toBe('stat');
+  });
+
+  it('serializes and deserializes stat buttons from JSON', () => {
+    service.setPanelName('Stats panel');
+    service.addStatBtn({
+      id: 'stat-rate',
+      name: 'Ratio',
+      colorHex: '#ffffff',
+      stat: {
+        mode: 'complex',
+        expression: {
+          kind: 'group',
+          op: '/',
+          left: { kind: 'constant', value: 10 },
+          right: { kind: 'constant', value: 2 },
+        },
+      },
+    });
+
+    const exported = service.exportAsJson();
+
+    const next = TestBed.inject(SequencerPanelService);
+    const imported = next.importFromJson(exported);
+
+    expect(imported).toBeTrue();
+    expect(next.panelName()).toBe('Stats panel');
+    expect(next.getBtnById('stat-rate')?.type).toBe('stat');
+  });
+
+  it('keeps event and label support unchanged', () => {
+    service.addEventBtn({
+      id: 'evt-1',
+      name: 'Event',
+      eventProps: { kind: 'limited', preMs: 0, postMs: 0 },
+    });
+    service.addLabelBtn({
+      id: 'lbl-1',
+      name: 'Label',
+      labelProps: { mode: 'once' },
+    });
+
+    const exported = service.exportAsJson();
+    const parsed = JSON.parse(exported) as { btnList: { type: string }[] };
+    const types = parsed.btnList.map(btn => btn.type);
+
+    expect(types).toContain('event');
+    expect(types).toContain('label');
+  });
+});

--- a/src/app/core/service/sequencer-panel.service.spec.ts
+++ b/src/app/core/service/sequencer-panel.service.spec.ts
@@ -70,4 +70,31 @@ describe('SequencerPanelService', () => {
     expect(types).toContain('event');
     expect(types).toContain('label');
   });
+
+  it('keeps complex editor displayName during json round-trip', () => {
+    service.addStatBtn({
+      id: 'stat-editor',
+      name: 'Editor',
+      stat: {
+        mode: 'complex',
+        expression: { kind: 'constant', value: 1 },
+        editor: {
+          terms: [
+            { id: 'term_1', displayName: 'Possessions', kind: 'query', query: { eventIds: ['evt_pos'], labelIds: [], metric: 'count', labelMatch: 'all' } },
+          ],
+          tokens: [{ kind: 'term', termId: 'term_1' }],
+        },
+      },
+    });
+
+    const exported = service.exportAsJson();
+    const imported = service.importFromJson(exported);
+
+    expect(imported).toBeTrue();
+    const btn = service.getBtnById('stat-editor');
+    expect(btn?.type).toBe('stat');
+    if (btn?.type === 'stat' && btn.stat.mode === 'complex') {
+      expect(btn.stat.editor?.terms[0].displayName).toBe('Possessions');
+    }
+  });
 });

--- a/src/app/core/service/sequencer-panel.service.ts
+++ b/src/app/core/service/sequencer-panel.service.ts
@@ -1,5 +1,13 @@
 import { Injectable, signal } from '@angular/core';
-import { EventBtn, LabelBtn, SequencerBtn } from '../../interfaces/sequencer-btn.interface';
+import {
+  EventBtn,
+  LabelBtn,
+  SequencerBtn,
+  SequencerStatDefinition,
+  SequencerStatNode,
+  SequencerStatQuery,
+  StatBtn,
+} from '../../interfaces/sequencer-btn.interface';
 import { SequencerBtnLayout } from '../../interfaces/sequencer-btn-layout.interface';
 import {
   defaultButtonHeightPx,
@@ -8,6 +16,11 @@ import {
   minButtonWidthPx,
   placementSpiral,
 } from '../../utils/sequencer/sequencer-canvas-defaults.util';
+
+interface SequencerPanelDocument {
+  panelName: string;
+  btnList: SequencerBtn[];
+}
 
 @Injectable({
   providedIn: 'root',
@@ -68,6 +81,42 @@ export class SequencerPanelService {
     newBtn.layout = this.ensureLayout(newBtn);
     this.btnListSignal.set([...this.btnListSignal(), newBtn]);
     return newBtn;
+  }
+
+  addStatBtn(payload: Omit<StatBtn, 'type'>): StatBtn | null {
+    const id = payload.id.trim();
+    if (!this.isIdAvailable(id)) {
+      return null;
+    }
+    const newBtn: StatBtn = {
+      ...payload,
+      id,
+      type: 'stat',
+      deactivateIds: this.normalizeLinkIds(payload.deactivateIds),
+      activateIds: this.normalizeLinkIds(payload.activateIds),
+    };
+    newBtn.layout = this.ensureLayout(newBtn);
+    this.btnListSignal.set([...this.btnListSignal(), newBtn]);
+    return newBtn;
+  }
+
+  exportAsJson(): string {
+    const document: SequencerPanelDocument = {
+      panelName: this.panelNameSignal(),
+      btnList: this.btnListSignal(),
+    };
+    return JSON.stringify(document, null, 2);
+  }
+
+  importFromJson(rawJson: string): boolean {
+    const parsed = JSON.parse(rawJson) as unknown;
+    if (!isSequencerPanelDocument(parsed)) {
+      return false;
+    }
+
+    this.panelNameSignal.set(parsed.panelName.trim() || 'My Panel');
+    this.btnListSignal.set(parsed.btnList.map(btn => ({ ...btn, layout: this.ensureLayout(btn) })));
+    return true;
   }
 
   ensureAllLayouts() {
@@ -254,4 +303,85 @@ export class SequencerPanelService {
 
     return points;
   }
+}
+
+function isSequencerPanelDocument(value: unknown): value is SequencerPanelDocument {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<SequencerPanelDocument>;
+  if (typeof candidate.panelName !== 'string' || !Array.isArray(candidate.btnList)) {
+    return false;
+  }
+
+  return candidate.btnList.every(isSequencerBtn);
+}
+
+function isSequencerBtn(value: unknown): value is SequencerBtn {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<SequencerBtn>;
+  if (typeof candidate.id !== 'string' || typeof candidate.name !== 'string') {
+    return false;
+  }
+
+  if (candidate.type === 'event') {
+    return !!candidate.eventProps;
+  }
+  if (candidate.type === 'label') {
+    return !!candidate.labelProps;
+  }
+  if (candidate.type === 'stat') {
+    return !!candidate.stat && isStatDefinition(candidate.stat);
+  }
+  return false;
+}
+
+function isStatDefinition(value: unknown): value is SequencerStatDefinition {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as SequencerStatDefinition;
+  if (candidate.mode === 'simple') {
+    return isStatQuery(candidate.query);
+  }
+
+  if (candidate.mode === 'complex') {
+    return isStatNode(candidate.expression);
+  }
+
+  return false;
+}
+
+function isStatQuery(value: unknown): value is SequencerStatQuery {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as SequencerStatQuery;
+  return Array.isArray(candidate.eventIds)
+    && Array.isArray(candidate.labelIds)
+    && candidate.metric === 'count'
+    && candidate.labelMatch === 'all';
+}
+
+function isStatNode(value: unknown): value is SequencerStatNode {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as SequencerStatNode;
+  if (candidate.kind === 'constant') {
+    return typeof candidate.value === 'number' && Number.isFinite(candidate.value);
+  }
+  if (candidate.kind === 'query') {
+    return isStatQuery(candidate.query);
+  }
+  if (candidate.kind === 'group') {
+    return ['+', '-', '*', '/'].includes(candidate.op) && isStatNode(candidate.left) && isStatNode(candidate.right);
+  }
+  return false;
 }

--- a/src/app/core/service/sequencer-panel.service.ts
+++ b/src/app/core/service/sequencer-panel.service.ts
@@ -4,6 +4,8 @@ import {
   LabelBtn,
   SequencerBtn,
   SequencerStatDefinition,
+  SequencerStatEditorTerm,
+  SequencerStatExpressionToken,
   SequencerStatNode,
   SequencerStatQuery,
   StatBtn,
@@ -351,7 +353,8 @@ function isStatDefinition(value: unknown): value is SequencerStatDefinition {
   }
 
   if (candidate.mode === 'complex') {
-    return isStatNode(candidate.expression);
+    return isStatNode(candidate.expression)
+      && (!candidate.editor || isStatEditor(candidate.editor));
   }
 
   return false;
@@ -362,12 +365,40 @@ function isStatQuery(value: unknown): value is SequencerStatQuery {
     return false;
   }
   const candidate = value as SequencerStatQuery;
+  const validColors = !candidate.labelColorById || Object.values(candidate.labelColorById).every(color => typeof color === 'string');
   return Array.isArray(candidate.eventIds)
     && Array.isArray(candidate.labelIds)
     && candidate.metric === 'count'
-    && candidate.labelMatch === 'all';
+    && candidate.labelMatch === 'all'
+    && validColors;
 }
 
+
+function isStatEditor(value: unknown): value is { terms: SequencerStatEditorTerm[]; tokens: SequencerStatExpressionToken[] } {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as { terms?: SequencerStatEditorTerm[]; tokens?: SequencerStatExpressionToken[] };
+  if (!Array.isArray(candidate.terms) || !Array.isArray(candidate.tokens)) {
+    return false;
+  }
+
+  const termsOk = candidate.terms.every(term =>
+    typeof term.id === 'string'
+    && typeof term.displayName === 'string'
+    && (term.kind === 'query' || term.kind === 'constant')
+    && (term.kind === 'query' ? !!term.query && isStatQuery(term.query) : typeof term.constantValue === 'number'),
+  );
+
+  const tokenOk = candidate.tokens.every(token =>
+    (token.kind === 'term' && typeof token.termId === 'string')
+    || (token.kind === 'operator' && ['+', '-', '*', '/'].includes(token.op))
+    || (token.kind === 'paren' && (token.value === '(' || token.value === ')')),
+  );
+
+  return termsOk && tokenOk;
+}
 function isStatNode(value: unknown): value is SequencerStatNode {
   if (!value || typeof value !== 'object') {
     return false;

--- a/src/app/core/service/sequencer-runtime.service.ts
+++ b/src/app/core/service/sequencer-runtime.service.ts
@@ -44,7 +44,7 @@ export class SequencerRuntimeService {
   trigger(btnId: string, source: 'hotkey' | 'click') {
     void source;
     const btn = this.panelService.getBtnById(btnId);
-    if (!btn || this.panelService.editMode()) {
+    if (!btn || this.panelService.editMode() || btn.type === 'stat') {
       return;
     }
 

--- a/src/app/core/services/sequencer-stats.service.spec.ts
+++ b/src/app/core/services/sequencer-stats.service.spec.ts
@@ -1,0 +1,140 @@
+import { TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
+import { SequencerPanelService } from '../service/sequencer-panel.service';
+import { TimelineFacadeService } from './timeline-facade.service';
+import { SequencerStatsService, formatStatValue } from './sequencer-stats.service';
+
+class MockSequencerPanelService {
+  readonly btnList = signal([
+    {
+      id: 'stat-simple-events',
+      name: 'Simple events',
+      type: 'stat' as const,
+      stat: { mode: 'simple' as const, query: { eventIds: ['evt_shot'], labelIds: [], metric: 'count' as const, labelMatch: 'all' as const } },
+    },
+    {
+      id: 'stat-simple-labels',
+      name: 'Simple labels',
+      type: 'stat' as const,
+      stat: { mode: 'simple' as const, query: { eventIds: ['evt_shot'], labelIds: ['lbl_on_target'], metric: 'count' as const, labelMatch: 'all' as const } },
+    },
+    {
+      id: 'stat-complex',
+      name: 'Complex',
+      type: 'stat' as const,
+      stat: {
+        mode: 'complex' as const,
+        expression: {
+          kind: 'group' as const,
+          op: '/',
+          left: {
+            kind: 'group' as const,
+            op: '+',
+            left: { kind: 'query' as const, query: { eventIds: ['evt_shot'], labelIds: ['lbl_on_target'], metric: 'count' as const, labelMatch: 'all' as const } },
+            right: { kind: 'constant' as const, value: 1 },
+          },
+          right: { kind: 'query' as const, query: { eventIds: ['evt_possession'], labelIds: [], metric: 'count' as const, labelMatch: 'all' as const } },
+        },
+      },
+    },
+    {
+      id: 'stat-div-zero',
+      name: 'Div zero',
+      type: 'stat' as const,
+      stat: {
+        mode: 'complex' as const,
+        expression: {
+          kind: 'group' as const,
+          op: '/',
+          left: { kind: 'constant' as const, value: 8 },
+          right: { kind: 'constant' as const, value: 0 },
+        },
+      },
+    },
+  ]);
+}
+
+class MockTimelineFacadeService {
+  readonly occurrences = signal([
+    { eventDefId: 'evt_shot', labelIds: ['lbl_on_target'] },
+    { eventDefId: 'evt_shot', labelIds: [] },
+    { eventDefId: 'evt_shot', labelIds: ['lbl_on_target', 'lbl_left'] },
+    { eventDefId: 'evt_possession', labelIds: [] },
+    { eventDefId: 'evt_possession', labelIds: [] },
+  ]);
+}
+
+describe('SequencerStatsService', () => {
+  let service: SequencerStatsService;
+  let timeline: MockTimelineFacadeService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        SequencerStatsService,
+        { provide: SequencerPanelService, useClass: MockSequencerPanelService },
+        { provide: TimelineFacadeService, useClass: MockTimelineFacadeService },
+      ],
+    });
+
+    service = TestBed.inject(SequencerStatsService);
+    timeline = TestBed.inject(TimelineFacadeService) as unknown as MockTimelineFacadeService;
+  });
+
+  it('counts simple query on event only', () => {
+    expect(service.valueByStatId()['stat-simple-events']).toBe(3);
+  });
+
+  it('counts simple query on event + labels(all)', () => {
+    expect(service.valueByStatId()['stat-simple-labels']).toBe(2);
+  });
+
+  it('returns zero when no results', () => {
+    const result = service.evaluateDefinition(
+      { mode: 'simple', query: { eventIds: ['evt_missing'], labelIds: [], metric: 'count', labelMatch: 'all' } },
+      timeline.occurrences(),
+    );
+    expect(result).toBe(0);
+  });
+
+  it('evaluates complex expression with constants and multiple operations', () => {
+    expect(service.valueByStatId()['stat-complex']).toBe(1.5);
+  });
+
+  it('supports priority through expression tree', () => {
+    const result = service.evaluateDefinition(
+      {
+        mode: 'complex',
+        expression: {
+          kind: 'group',
+          op: '+',
+          left: { kind: 'constant', value: 1 },
+          right: {
+            kind: 'group',
+            op: '*',
+            left: { kind: 'constant', value: 2 },
+            right: { kind: 'constant', value: 3 },
+          },
+        },
+      },
+      timeline.occurrences(),
+    );
+
+    expect(result).toBe(7);
+  });
+
+  it('returns null on division by zero and displays em dash', () => {
+    expect(service.valueByStatId()['stat-div-zero']).toBeNull();
+    expect(service.getDisplayValue('stat-div-zero')).toBe('—');
+  });
+
+  it('recalculates live when analysis occurrences change', () => {
+    timeline.occurrences.set([...timeline.occurrences(), { eventDefId: 'evt_shot', labelIds: [] }]);
+    expect(service.valueByStatId()['stat-simple-events']).toBe(4);
+  });
+
+  it('formats display values with max 2 decimals', () => {
+    expect(formatStatValue(4)).toBe('4');
+    expect(formatStatValue(1.236)).toBe('1.24');
+  });
+});

--- a/src/app/core/services/sequencer-stats.service.ts
+++ b/src/app/core/services/sequencer-stats.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, computed, inject } from '@angular/core';
+import { SequencerPanelService } from '../service/sequencer-panel.service';
+import { TimelineFacadeService } from './timeline-facade.service';
+import { SequencerStatDefinition, SequencerStatNode, SequencerStatOperator, SequencerStatQuery } from '../../interfaces/sequencer-btn.interface';
+
+@Injectable({ providedIn: 'root' })
+export class SequencerStatsService {
+  private readonly panelService = inject(SequencerPanelService);
+  private readonly timelineFacade = inject(TimelineFacadeService);
+
+  readonly valueByStatId = computed<Record<string, number | null>>(() => {
+    const stats = this.panelService.btnList().filter(btn => btn.type === 'stat');
+    const occurrences = this.timelineFacade.occurrences();
+
+    return stats.reduce<Record<string, number | null>>((acc, statBtn) => {
+      acc[statBtn.id] = this.evaluateDefinition(statBtn.stat, occurrences);
+      return acc;
+    }, {});
+  });
+
+  readonly exportRows = computed(() =>
+    this.panelService
+      .btnList()
+      .filter(btn => btn.type === 'stat')
+      .map(btn => ({
+        id: btn.id,
+        name: btn.name,
+        value: this.valueByStatId()[btn.id] ?? null,
+        definition: btn.stat,
+      })),
+  );
+
+  getDisplayValue(btnId: string): string {
+    const value = this.valueByStatId()[btnId] ?? null;
+    return formatStatValue(value);
+  }
+
+  evaluateDefinition(definition: SequencerStatDefinition, occurrences: { eventDefId: string; labelIds: string[] }[]): number | null {
+    if (definition.mode === 'simple') {
+      return this.evaluateSimpleQuery(definition.query, occurrences);
+    }
+    return this.evaluateNode(definition.expression, occurrences);
+  }
+
+  private evaluateNode(node: SequencerStatNode, occurrences: { eventDefId: string; labelIds: string[] }[]): number | null {
+    if (node.kind === 'constant') {
+      return node.value;
+    }
+
+    if (node.kind === 'query') {
+      return this.evaluateSimpleQuery(node.query, occurrences);
+    }
+
+    const left = this.evaluateNode(node.left, occurrences);
+    const right = this.evaluateNode(node.right, occurrences);
+
+    if (left === null || right === null || Number.isNaN(left) || Number.isNaN(right)) {
+      return null;
+    }
+
+    return applyOperator(left, right, node.op);
+  }
+
+  private evaluateSimpleQuery(query: SequencerStatQuery, occurrences: { eventDefId: string; labelIds: string[] }[]): number {
+    const eventIds = new Set(query.eventIds);
+    if (!eventIds.size) {
+      return 0;
+    }
+
+    const selectedLabelIds = new Set(query.labelIds);
+
+    return occurrences.filter(occurrence => {
+      if (!eventIds.has(occurrence.eventDefId)) {
+        return false;
+      }
+
+      if (!selectedLabelIds.size) {
+        return true;
+      }
+
+      const labels = new Set(occurrence.labelIds);
+      return [...selectedLabelIds].every(labelId => labels.has(labelId));
+    }).length;
+  }
+}
+
+function applyOperator(left: number, right: number, op: SequencerStatOperator): number | null {
+  if (op === '+') {
+    return left + right;
+  }
+  if (op === '-') {
+    return left - right;
+  }
+  if (op === '*') {
+    return left * right;
+  }
+  if (op === '/') {
+    if (right === 0) {
+      return null;
+    }
+    return left / right;
+  }
+
+  return null;
+}
+
+export function formatStatValue(value: number | null): string {
+  if (value === null || Number.isNaN(value) || !Number.isFinite(value)) {
+    return '—';
+  }
+
+  const rounded = Math.round(value * 100) / 100;
+  if (Number.isInteger(rounded)) {
+    return `${rounded}`;
+  }
+
+  return `${rounded}`;
+}

--- a/src/app/interfaces/sequencer-btn.interface.ts
+++ b/src/app/interfaces/sequencer-btn.interface.ts
@@ -1,11 +1,40 @@
 import { SequencerBtnLayout } from './sequencer-btn-layout.interface';
 
-export type SequencerBtn = EventBtn | LabelBtn;
+export type SequencerStatOperator = '+' | '-' | '*' | '/';
+
+export interface SequencerStatQuery {
+  eventIds: string[];
+  labelIds: string[];
+  metric: 'count';
+  labelMatch: 'all';
+}
+
+export type SequencerStatNode =
+  | { kind: 'constant'; value: number }
+  | { kind: 'query'; query: SequencerStatQuery }
+  | {
+      kind: 'group';
+      left: SequencerStatNode;
+      op: SequencerStatOperator;
+      right: SequencerStatNode;
+    };
+
+export type SequencerStatDefinition =
+  | {
+      mode: 'simple';
+      query: SequencerStatQuery;
+    }
+  | {
+      mode: 'complex';
+      expression: SequencerStatNode;
+    };
+
+export type SequencerBtn = EventBtn | LabelBtn | StatBtn;
 
 export interface SequencerBtnBase {
   id: string;
   name: string;
-  type: 'event' | 'label';
+  type: 'event' | 'label' | 'stat';
   hotkeyNormalized?: string | null;
   deactivateIds?: string[];
   activateIds?: string[];
@@ -27,4 +56,10 @@ export interface LabelBtn extends SequencerBtnBase {
   labelProps: {
     mode: 'once' | 'indefinite';
   };
+}
+
+export interface StatBtn extends SequencerBtnBase {
+  type: 'stat';
+  colorHex?: string;
+  stat: SequencerStatDefinition;
 }

--- a/src/app/interfaces/sequencer-btn.interface.ts
+++ b/src/app/interfaces/sequencer-btn.interface.ts
@@ -5,6 +5,7 @@ export type SequencerStatOperator = '+' | '-' | '*' | '/';
 export interface SequencerStatQuery {
   eventIds: string[];
   labelIds: string[];
+  labelColorById?: Record<string, string>;
   metric: 'count';
   labelMatch: 'all';
 }
@@ -19,6 +20,19 @@ export type SequencerStatNode =
       right: SequencerStatNode;
     };
 
+export interface SequencerStatEditorTerm {
+  id: string;
+  displayName: string;
+  kind: 'query' | 'constant';
+  query?: SequencerStatQuery;
+  constantValue?: number;
+}
+
+export type SequencerStatExpressionToken =
+  | { kind: 'term'; termId: string }
+  | { kind: 'operator'; op: SequencerStatOperator }
+  | { kind: 'paren'; value: '(' | ')' };
+
 export type SequencerStatDefinition =
   | {
       mode: 'simple';
@@ -27,6 +41,10 @@ export type SequencerStatDefinition =
   | {
       mode: 'complex';
       expression: SequencerStatNode;
+      editor?: {
+        terms: SequencerStatEditorTerm[];
+        tokens: SequencerStatExpressionToken[];
+      };
     };
 
 export type SequencerBtn = EventBtn | LabelBtn | StatBtn;

--- a/src/theme/_global.class.scss
+++ b/src/theme/_global.class.scss
@@ -73,6 +73,16 @@
   }
 }
 
+.seq-btn-stat {
+  border-radius: 2rem;
+  background-color: var(--sequencer-stat-bg) !important;
+  border-color: var(--sequencer-stat-border) !important;
+  color: var(--sequencer-stat-text);
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
 .seq-btn-event-card {
   border-color: var(--sequencer-event-border) !important;
 }

--- a/src/theme/variables/_global.variables.scss
+++ b/src/theme/variables/_global.variables.scss
@@ -19,6 +19,9 @@
   --sequencer-label-bg: #4a2f22;
   --sequencer-label-border: #7a543d;
   --sequencer-label-text: #fff6ee;
+  --sequencer-stat-bg: #1f4b73;
+  --sequencer-stat-border: #3d77a7;
+  --sequencer-stat-text: #eff6ff;
 
   --light: #FAFAFA;
   --light-text-disabled: #C3C3C3;
@@ -50,6 +53,9 @@
   --sequencer-label-bg: #4a2f22;
   --sequencer-label-border: #7a543d;
   --sequencer-label-text: #fff6ee;
+  --sequencer-stat-bg: #1f4b73;
+  --sequencer-stat-border: #3d77a7;
+  --sequencer-stat-text: #eff6ff;
 
   --light: #FAFAFA;
   --light-text-disabled: #C3C3C3;


### PR DESCRIPTION
### Motivation
- Provide a first-class `stat` button in the Sequencer so users can add live metrics computed from the current analysis and prepare for future JSON → Excel export. 
- Keep the existing `event`/`label` behaviour unchanged while adding a typed, serializable and extensible model for statistics (simple queries + composable complex expressions). 

### Description
- Add a typed JSON model and new button type `stat` with `SequencerStatQuery`, `SequencerStatNode` and `SequencerStatDefinition` and a `StatBtn` union variant in `src/app/interfaces/sequencer-btn.interface.ts`. 
- Extend `SequencerPanelService` with `addStatBtn(...)`, robust `exportAsJson()`/`importFromJson()` and runtime validation helpers so `stat` buttons are persisted and round-tripped with the panel JSON in `src/app/core/service/sequencer-panel.service.ts`. 
- Implement `SequencerStatsService` (signals/computed) that reads timeline occurrences, evaluates simple `count` queries and recursive complex expressions (`+ - * /`), handles division-by-zero / invalid -> `null`, and exposes `valueByStatId`, `getDisplayValue()` and `exportRows` for future export in `src/app/core/services/sequencer-stats.service.ts`. 
- UI integration: add a topbar `Stats` button (`query_stats`) to create stats, a structured editor dialog `CreateStatBtnDialogComponent` supporting simple/complex modes, show `gesture_select` icon in edit mode, and render stat cards on the canvas showing live values (informational only, no runtime triggers) with theme classes and variables (`seq-btn-stat`) in `src/app/components/analyse/sequencer/*` and `src/theme/*`. 
- Ensure runtime ignores clicks/hotkeys on `stat` buttons (`SequencerRuntimeService`) and keep existing sequencing behavior for `event`/`label` intact. 
- Add focused unit tests for panel and stats logic and update `codex.md` with the new `stat` type and V1 rules. 

### Testing
- Lint: ran `npm run lint` and fixed issues introduced during changes; final lint run completed successfully (All files pass linting). 
- Unit tests: added `src/app/core/service/sequencer-panel.service.spec.ts` and `src/app/core/services/sequencer-stats.service.spec.ts` covering creation, JSON round-trip, simple queries, label filters, complex expressions, priority, division-by-zero, live recalculation and display formatting. 
- Test run: attempted `npm test` (targeting the new specs) but the test run failed for the whole project due to existing TypeScript environment/global type issues (`process` not found in `runtime-environment.ts`) unrelated to the new stats logic; the new specs themselves are present and exercise the stats logic but could not complete because of that global compile error. 
- Notes: the failures are environmental (ts config / node types) and not caused by the `stat` implementation; once the global TS issue is addressed the new tests should run and validate the feature.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b1e8e2448326bb73d7745eae8dec)