### PR TITLE
feat(analyse): wire sequencer and timeline export logs

### DIFF
--- a/src/app/components/analyse/sequencer/sequencer-panel.component.html
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.html
@@ -8,7 +8,7 @@
       <div class="text-muted text-[11px]">Agrandir pour éditer le Sequencer Canvas.</div>
     </div>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item disabled>Export</button>
+      <button mat-menu-item type="button" (click)="handleExportSequencer()">Export</button>
       <button mat-menu-item disabled>Import</button>
       <button mat-menu-item disabled>Save</button>
       <button mat-menu-item disabled>SeeAllMyPanels</button>
@@ -23,7 +23,9 @@
           <mat-icon aria-hidden="true">edit</mat-icon>
           <span>Renommer</span>
         </button>
-        <button mat-menu-item disabled>Export</button>
+        <button mat-menu-item type="button" (click)="handleExportSequencer()">
+          <span>Export</span>
+        </button>
         <button mat-menu-item disabled>Import</button>
         <button mat-menu-item disabled>Save</button>
         <button mat-menu-item disabled>SeeAllMyPanels</button>

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.ts
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.ts
@@ -49,6 +49,7 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
 
   readonly panelName = this.panelService.panelName;
   readonly btnList = this.panelService.btnList;
+  readonly panel = this.panelService.panel;
   readonly editMode = this.panelService.editMode;
   readonly lastTriggeredBtnId = this.runtimeService.lastTriggeredBtnId;
   readonly activeIndefiniteIds = this.runtimeService.activeIndefiniteIds;
@@ -157,6 +158,10 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
       return;
     }
     this.renameDraft.set(target.value);
+  }
+
+  handleExportSequencer() {
+    console.log('[Sequencer Export]', this.panel());
   }
 
 }

--- a/src/app/components/analyse/timeline/timeline.component.html
+++ b/src/app/components/analyse/timeline/timeline.component.html
@@ -62,6 +62,16 @@
     <button
       class="btn-secondary ml-auto flex items-center justify-center"
       type="button"
+      aria-label="Exporter la timeline"
+      title="Exporter la timeline"
+      (click)="handleExportTimeline()"
+    >
+      <mat-icon>file_upload</mat-icon>
+    </button>
+
+    <button
+      class="btn-secondary flex items-center justify-center"
+      type="button"
       aria-label="Supprimer la sélection"
       [attr.title]="deleteSelectionTooltip()"
       [disabled]="!canDeleteSelection()"

--- a/src/app/components/analyse/timeline/timeline.component.ts
+++ b/src/app/components/analyse/timeline/timeline.component.ts
@@ -489,6 +489,10 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
     this.facade.setAutoFollow(true);
   }
 
+  handleExportTimeline() {
+    console.log('[Timeline Export]', this.facade.timelineState());
+  }
+
   private isTextInputTarget(target: EventTarget | null) {
     if (!(target instanceof HTMLElement)) {
       return false;

--- a/src/app/core/service/sequencer-panel.service.ts
+++ b/src/app/core/service/sequencer-panel.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, signal } from '@angular/core';
+import { Injectable, computed, signal } from '@angular/core';
 import {
   EventBtn,
   LabelBtn,
@@ -36,6 +36,10 @@ export class SequencerPanelService {
 
   private readonly editModeSignal = signal(false);
   readonly editMode = this.editModeSignal.asReadonly();
+  readonly panel = computed(() => ({
+    panelName: this.panelNameSignal(),
+    btnList: this.btnListSignal(),
+  }));
 
   private zCounter = 0;
 

--- a/src/app/core/services/timeline-facade.service.ts
+++ b/src/app/core/services/timeline-facade.service.ts
@@ -35,6 +35,7 @@ import {
   selectTimelineOccurrences,
   selectTimelineScroll,
   selectTimelineSelectionIds,
+  selectTimelineState,
 } from '../../store/Timeline/timeline.selectors';
 import { mergeIntervalsForPlayback, normalizeTiming } from '../../utils/timeline/timeline-time.utils';
 
@@ -55,6 +56,7 @@ export class TimelineFacadeService {
   readonly canUndoShiftOrAlign = this.store.selectSignal(selectTimelineCanUndoShiftAlign);
   readonly canUndoRemove = this.store.selectSignal(selectTimelineCanUndoRemove);
   readonly allOccurrencesSelected = this.store.selectSignal(selectTimelineAllOccurrencesSelected);
+  readonly timelineState = this.store.selectSignal(selectTimelineState);
 
   readonly hasChronoOrVideo: Signal<boolean> = computed(
     () => this.timebase.mode() === 'video' || this.timebase.currentTimeMs() > 0,


### PR DESCRIPTION
### Motivation
- Provide a safe, non-destructive way to inspect the real runtime objects backing the Sequencer panel and the Timeline in preparation for a future JSON export.
- Activate the existing UI affordances so users can grab the actual in-memory objects without mocking, persisting, downloading or calling the backend.
- Keep changes minimal and consistent with existing patterns (signals/facades), keeping the UX unchanged except for the new export affordance in the timeline header.

### Description
- Expose a computed `panel` signal in `SequencerPanelService` that returns the current `{ panelName, btnList }` from the existing `panelNameSignal` and `btnListSignal` and use it as the canonical sequencer object to export. (`src/app/core/service/sequencer-panel.service.ts`)
- Activate the existing `Export` menu entry in the sequencer (compact + expanded modes) and wire it to `handleExportSequencer()` which logs the real panel with `console.log('[Sequencer Export]', this.panel())`. (`src/app/components/analyse/sequencer/sequencer-panel.component.html`, `src/app/components/analyse/sequencer/sequencer-panel.component.ts`)
- Expose the full timeline feature state as a signal `timelineState` in `TimelineFacadeService` (selecting `selectTimelineState`) to make the real `TimelineState` available for export. (`src/app/core/services/timeline-facade.service.ts`)
- Add an export button to the timeline header using a Material file-export icon (`file_upload`) and wire it to `handleExportTimeline()` which logs the real timeline state with `console.log('[Timeline Export]', this.facade.timelineState())`. (`src/app/components/analyse/timeline/timeline.component.html`, `src/app/components/analyse/timeline/timeline.component.ts`)
- No mocks, no payload shaping beyond exposing existing signals, no persistence, no backend calls, and no download behavior have been implemented.

### Testing
- Automated linting: ran `npm run lint` and all files passed linting (success).
- Full build: ran `npm run build` and application bundles were generated successfully (build completed; prerender/runtime warnings observed in logs but they are unrelated and non-blocking).
- No unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c8d5ee7af883268b73ad0071f403b9)