### PR TITLE
feat(analysis-store): add typed interfaces and API client scaffold

### DIFF
--- a/src/app/core/api/analysis-store.api.ts
+++ b/src/app/core/api/analysis-store.api.ts
@@ -1,0 +1,101 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { runtimeEnvironment } from '../config/runtime-environment';
+import {
+  AnalysisStoreImportValidationPayload,
+  AnalysisTimelineV1,
+  CreatePanelResourceBody,
+  CreateTimelineResourceBody,
+  PanelImportValidationResponse,
+  PanelResourceResponse,
+  SequencerPanelV1,
+  TimelineImportValidationResponse,
+  TimelineResourceResponse,
+  UpdatePanelResourceBody,
+  UpdateTimelineResourceBody,
+  UpsertPanelResourceBody,
+  UpsertTimelineResourceBody,
+} from '../../interfaces/analysis-store';
+
+@Injectable({ providedIn: 'root' })
+export class AnalysisStoreApi {
+  private readonly http = inject(HttpClient);
+  private readonly endpoints = runtimeEnvironment.analysisStoreEndpoints;
+
+  validateTimelineImport(payload: AnalysisStoreImportValidationPayload): Observable<TimelineImportValidationResponse> {
+    return this.http.post<TimelineImportValidationResponse>(this.endpoints.importsTimelinesValidate, payload);
+  }
+
+  validatePanelImport(payload: AnalysisStoreImportValidationPayload): Observable<PanelImportValidationResponse> {
+    return this.http.post<PanelImportValidationResponse>(this.endpoints.importsPanelsValidate, payload);
+  }
+
+  listTimelines(): Observable<TimelineResourceResponse[]> {
+    return this.http.get<TimelineResourceResponse[]>(this.endpoints.timelines);
+  }
+
+  getTimeline(id: string): Observable<TimelineResourceResponse> {
+    return this.http.get<TimelineResourceResponse>(this.buildResourceUrl(this.endpoints.timelines, id));
+  }
+
+  exportTimeline(id: string): Observable<AnalysisTimelineV1> {
+    return this.http.get<AnalysisTimelineV1>(this.buildExportUrl(this.endpoints.timelines, id));
+  }
+
+  upsertTimeline(payload: UpsertTimelineResourceBody): Observable<TimelineResourceResponse> {
+    return payload.id ? this.updateTimeline(payload.id, payload) : this.createTimeline(payload);
+  }
+
+  createTimeline(payload: CreateTimelineResourceBody): Observable<TimelineResourceResponse> {
+    return this.http.post<TimelineResourceResponse>(this.endpoints.timelines, payload);
+  }
+
+  updateTimeline(id: string, payload: UpdateTimelineResourceBody): Observable<TimelineResourceResponse> {
+    return this.http.patch<TimelineResourceResponse>(this.buildResourceUrl(this.endpoints.timelines, id), payload);
+  }
+
+  deleteTimeline(id: string): Observable<void> {
+    return this.http.delete<void>(this.buildResourceUrl(this.endpoints.timelines, id));
+  }
+
+  listPanels(): Observable<PanelResourceResponse[]> {
+    return this.http.get<PanelResourceResponse[]>(this.endpoints.panels);
+  }
+
+  getPanel(id: string): Observable<PanelResourceResponse> {
+    return this.http.get<PanelResourceResponse>(this.buildResourceUrl(this.endpoints.panels, id));
+  }
+
+  exportPanel(id: string): Observable<SequencerPanelV1> {
+    return this.http.get<SequencerPanelV1>(this.buildExportUrl(this.endpoints.panels, id));
+  }
+
+  upsertPanel(payload: UpsertPanelResourceBody): Observable<PanelResourceResponse> {
+    return payload.id ? this.updatePanel(payload.id, payload) : this.createPanel(payload);
+  }
+
+  createPanel(payload: CreatePanelResourceBody): Observable<PanelResourceResponse> {
+    return this.http.post<PanelResourceResponse>(this.endpoints.panels, payload);
+  }
+
+  updatePanel(id: string, payload: UpdatePanelResourceBody): Observable<PanelResourceResponse> {
+    return this.http.patch<PanelResourceResponse>(this.buildResourceUrl(this.endpoints.panels, id), payload);
+  }
+
+  deletePanel(id: string): Observable<void> {
+    return this.http.delete<void>(this.buildResourceUrl(this.endpoints.panels, id));
+  }
+
+  copyPanel(id: string): Observable<PanelResourceResponse> {
+    return this.http.post<PanelResourceResponse>(`${this.buildResourceUrl(this.endpoints.panels, id)}/copy`, {});
+  }
+
+  private buildResourceUrl(collectionUrl: string, id: string): string {
+    return `${collectionUrl}/${encodeURIComponent(id)}`;
+  }
+
+  private buildExportUrl(collectionUrl: string, id: string): string {
+    return `${this.buildResourceUrl(collectionUrl, id)}/export`;
+  }
+}

--- a/src/app/core/config/runtime-environment.ts
+++ b/src/app/core/config/runtime-environment.ts
@@ -36,6 +36,7 @@ function readServerRuntimeConfig(): RuntimeConfigShape {
   }
 
   const authPrefix = process.env['AUTH_API_PREFIX']?.trim() || '';
+  const analysisStorePrefix = process.env['ANALYSIS_STORE_API_PREFIX']?.trim() || '';
 
   return {
     apiAllowedPrefixes: parseCsv(process.env['API_ALLOWED_PREFIXES'], environment.apiAllowedPrefixes),
@@ -45,6 +46,16 @@ function readServerRuntimeConfig(): RuntimeConfigShape {
       refresh: process.env['AUTH_REFRESH_ENDPOINT'] || `${authPrefix}/auth/refresh`,
       logout: process.env['AUTH_LOGOUT_ENDPOINT'] || `${authPrefix}/auth/logout`,
       me: process.env['AUTH_ME_ENDPOINT'] || `${authPrefix}/me`,
+    },
+    analysisStoreEndpoints: {
+      importsTimelinesValidate:
+        process.env['ANALYSIS_STORE_IMPORTS_TIMELINES_VALIDATE_ENDPOINT'] ||
+        `${analysisStorePrefix}/api/imports/timelines/validate`,
+      importsPanelsValidate:
+        process.env['ANALYSIS_STORE_IMPORTS_PANELS_VALIDATE_ENDPOINT'] ||
+        `${analysisStorePrefix}/api/imports/panels/validate`,
+      timelines: process.env['ANALYSIS_STORE_TIMELINES_ENDPOINT'] || `${analysisStorePrefix}/api/timelines`,
+      panels: process.env['ANALYSIS_STORE_PANELS_ENDPOINT'] || `${analysisStorePrefix}/api/panels`,
     },
   };
 }
@@ -59,6 +70,16 @@ function mergeWithDefaults(runtimeConfig: RuntimeConfigShape): AppEnvironment {
       refresh: runtimeConfig.authEndpoints?.refresh ?? environment.authEndpoints.refresh,
       logout: runtimeConfig.authEndpoints?.logout ?? environment.authEndpoints.logout,
       me: runtimeConfig.authEndpoints?.me ?? environment.authEndpoints.me,
+    },
+    analysisStoreEndpoints: {
+      importsTimelinesValidate:
+        runtimeConfig.analysisStoreEndpoints?.importsTimelinesValidate ??
+        environment.analysisStoreEndpoints.importsTimelinesValidate,
+      importsPanelsValidate:
+        runtimeConfig.analysisStoreEndpoints?.importsPanelsValidate ??
+        environment.analysisStoreEndpoints.importsPanelsValidate,
+      timelines: runtimeConfig.analysisStoreEndpoints?.timelines ?? environment.analysisStoreEndpoints.timelines,
+      panels: runtimeConfig.analysisStoreEndpoints?.panels ?? environment.analysisStoreEndpoints.panels,
     },
   };
 }

--- a/src/app/interfaces/analysis-store/analysis-store-imports.interface.ts
+++ b/src/app/interfaces/analysis-store/analysis-store-imports.interface.ts
@@ -1,0 +1,6 @@
+import { AnalysisTimelineV1, TimelineImportValidationResponse } from './analysis-store-timeline.interface';
+import { PanelImportValidationResponse, SequencerPanelV1 } from './analysis-store-panel.interface';
+
+export type AnalysisStoreImportValidationPayload = AnalysisTimelineV1 | SequencerPanelV1 | Record<string, unknown>;
+
+export type AnalysisStoreValidationAnyResponse = TimelineImportValidationResponse | PanelImportValidationResponse;

--- a/src/app/interfaces/analysis-store/analysis-store-panel.interface.ts
+++ b/src/app/interfaces/analysis-store/analysis-store-panel.interface.ts
@@ -1,0 +1,95 @@
+import {
+  AnalysisStoreMetaV1,
+  AnalysisStoreResourceResponse,
+  AnalysisStoreSchemaVersion,
+  AnalysisStoreValidationResponse,
+  AnalysisStoreVisibility,
+} from './analysis-store-shared.interface';
+
+export interface SequencerPanelLayoutV1 {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  z: number;
+}
+
+export interface SequencerPanelBtnBaseV1 {
+  id: string;
+  name: string;
+  layout: SequencerPanelLayoutV1;
+  hotkeyNormalized: string | null;
+  deactivateIds: string[];
+  activateIds: string[];
+}
+
+export interface SequencerPanelEventBtnV1 extends SequencerPanelBtnBaseV1 {
+  type: 'event';
+  eventProps: {
+    eventName: string;
+    colorHex: string | null;
+  };
+}
+
+export interface SequencerPanelLabelBtnV1 extends SequencerPanelBtnBaseV1 {
+  type: 'label';
+  labelProps: {
+    label: string;
+    colorHex: string | null;
+  };
+}
+
+export interface SequencerPanelStatBtnV1 extends SequencerPanelBtnBaseV1 {
+  type: 'stat';
+  stat: {
+    statName: string;
+    value: number;
+    colorHex: string | null;
+  };
+}
+
+export type SequencerPanelBtnV1 = SequencerPanelEventBtnV1 | SequencerPanelLabelBtnV1 | SequencerPanelStatBtnV1;
+
+export interface SequencerPanelV1 {
+  schemaVersion: AnalysisStoreSchemaVersion;
+  type: 'sequencer-panel';
+  panelName: string;
+  meta: AnalysisStoreMetaV1;
+  btnList: SequencerPanelBtnV1[];
+}
+
+export interface PanelImportValidationSummary {
+  panelName: string;
+  buttonCount: number;
+  eventButtonCount: number;
+  labelButtonCount: number;
+  statButtonCount: number;
+}
+
+export type PanelImportValidationResponse = AnalysisStoreValidationResponse<
+  'sequencer-panel',
+  PanelImportValidationSummary,
+  SequencerPanelV1
+>;
+
+export type PanelResourceResponse = AnalysisStoreResourceResponse;
+
+export interface CreatePanelResourceBody {
+  title: string;
+  description?: string | null;
+  contentJson: Record<string, unknown>;
+  visibility?: AnalysisStoreVisibility;
+  clubId?: string | null;
+  hasAnonymizedContent?: boolean;
+}
+
+export interface UpdatePanelResourceBody {
+  title?: string;
+  description?: string | null;
+  contentJson: Record<string, unknown>;
+  visibility?: AnalysisStoreVisibility;
+  clubId?: string | null;
+  hasAnonymizedContent?: boolean;
+}
+
+export type UpsertPanelResourceBody = (CreatePanelResourceBody | UpdatePanelResourceBody) & { id?: string };

--- a/src/app/interfaces/analysis-store/analysis-store-shared.interface.ts
+++ b/src/app/interfaces/analysis-store/analysis-store-shared.interface.ts
@@ -1,0 +1,41 @@
+export type AnalysisStoreSchemaVersion = '1.0.0';
+export type AnalysisStoreDocumentType = 'analysis-timeline' | 'sequencer-panel';
+export type AnalysisStoreVisibility = 'private' | 'club' | 'public';
+
+export interface AnalysisStoreMetaV1 {
+  createdAtIso: string;
+  updatedAtIso: string;
+  exportedAtIso: string;
+  sourceUserId: string | null;
+  sourceApp: string;
+  sourceAppVersion: string;
+}
+
+export interface AnalysisStoreValidationError {
+  code: string;
+  path: string;
+  message: string;
+}
+
+export interface AnalysisStoreValidationResponse<TType extends AnalysisStoreDocumentType, TSummary, TNormalizedPayload> {
+  type: TType;
+  schemaVersion: AnalysisStoreSchemaVersion;
+  valid: boolean;
+  detectedType: AnalysisStoreDocumentType | null;
+  summary: TSummary;
+  normalizedPayload: TNormalizedPayload | null;
+  errors: AnalysisStoreValidationError[];
+}
+
+export interface AnalysisStoreResourceResponse {
+  id: string;
+  ownerUserId: string;
+  title: string;
+  description: string | null;
+  visibility: AnalysisStoreVisibility;
+  clubId: string | null;
+  contentJson: Record<string, unknown>;
+  hasAnonymizedContent: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/app/interfaces/analysis-store/analysis-store-timeline.interface.ts
+++ b/src/app/interfaces/analysis-store/analysis-store-timeline.interface.ts
@@ -1,0 +1,75 @@
+import {
+  AnalysisStoreMetaV1,
+  AnalysisStoreResourceResponse,
+  AnalysisStoreSchemaVersion,
+  AnalysisStoreValidationResponse,
+} from './analysis-store-shared.interface';
+
+export interface AnalysisTimelineEventDefV1 {
+  id: string;
+  name: string;
+  colorHex: string | null;
+}
+
+export interface AnalysisTimelineLabelDefV1 {
+  id: string;
+  name: string;
+  colorHex: string | null;
+}
+
+export interface AnalysisTimelineOccurrenceV1 {
+  id: string;
+  eventDefId: string | null;
+  labelDefId: string | null;
+  occurredAtIso: string;
+  durationMs: number;
+  note: string | null;
+}
+
+export interface AnalysisTimelineUiV1 {
+  zoom: number;
+  showLabels: boolean;
+  selectedOccurrenceId: string | null;
+}
+
+export interface AnalysisTimelineV1 {
+  schemaVersion: AnalysisStoreSchemaVersion;
+  type: 'analysis-timeline';
+  timelineName: string;
+  meta: AnalysisStoreMetaV1;
+  eventDefs: AnalysisTimelineEventDefV1[];
+  labelDefs: AnalysisTimelineLabelDefV1[];
+  occurrences: AnalysisTimelineOccurrenceV1[];
+  ui: AnalysisTimelineUiV1;
+}
+
+export interface TimelineImportValidationSummary {
+  timelineName: string;
+  eventDefCount: number;
+  labelDefCount: number;
+  occurrenceCount: number;
+}
+
+export type TimelineImportValidationResponse = AnalysisStoreValidationResponse<
+  'analysis-timeline',
+  TimelineImportValidationSummary,
+  AnalysisTimelineV1
+>;
+
+export type TimelineResourceResponse = AnalysisStoreResourceResponse;
+
+export interface CreateTimelineResourceBody {
+  title: string;
+  description?: string | null;
+  contentJson: Record<string, unknown>;
+  hasAnonymizedContent?: boolean;
+}
+
+export interface UpdateTimelineResourceBody {
+  title?: string;
+  description?: string | null;
+  contentJson: Record<string, unknown>;
+  hasAnonymizedContent?: boolean;
+}
+
+export type UpsertTimelineResourceBody = (CreateTimelineResourceBody | UpdateTimelineResourceBody) & { id?: string };

--- a/src/app/interfaces/analysis-store/index.ts
+++ b/src/app/interfaces/analysis-store/index.ts
@@ -1,0 +1,4 @@
+export * from './analysis-store-shared.interface';
+export * from './analysis-store-timeline.interface';
+export * from './analysis-store-panel.interface';
+export * from './analysis-store-imports.interface';

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -14,4 +14,10 @@ export const environment: AppEnvironment = {
     logout: '/auth/logout',
     me: '/me',
   },
+  analysisStoreEndpoints: {
+    importsTimelinesValidate: '/api/imports/timelines/validate',
+    importsPanelsValidate: '/api/imports/panels/validate',
+    timelines: '/api/timelines',
+    panels: '/api/panels',
+  },
 };

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -8,4 +8,10 @@ export interface AppEnvironment {
     logout: string;
     me: string;
   };
+  analysisStoreEndpoints: {
+    importsTimelinesValidate: string;
+    importsPanelsValidate: string;
+    timelines: string;
+    panels: string;
+  };
 }

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -14,4 +14,10 @@ export const environment: AppEnvironment = {
     logout: '/auth/logout',
     me: '/me',
   },
+  analysisStoreEndpoints: {
+    importsTimelinesValidate: '/api/imports/timelines/validate',
+    importsPanelsValidate: '/api/imports/panels/validate',
+    timelines: '/api/timelines',
+    panels: '/api/panels',
+  },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -10,4 +10,10 @@ export const environment: AppEnvironment = {
     logout: '/auth/logout',
     me: '/me',
   },
+  analysisStoreEndpoints: {
+    importsTimelinesValidate: '/api/imports/timelines/validate',
+    importsPanelsValidate: '/api/imports/panels/validate',
+    timelines: '/api/timelines',
+    panels: '/api/panels',
+  },
 };


### PR DESCRIPTION
### Motivation
- Prepare the front for integration with the `analysis-store` service by providing strict TypeScript contracts and a typed HTTP client aligned with the documented API in `docs/API/analysis-store/README.md`.
- Respect the repository architecture and patterns (interfaces in `src/app/interfaces`, API clients in `src/app/core/api`, and runtime environment config) so later wiring to NgRx/store and UI can follow existing conventions.
- Ensure the front enforces important backend rules (PATCH requires `contentJson`, create vs update based on `id`, `export` routes return raw business JSON) at the type level to avoid future regressions.

### Description
- Added a new typed interfaces folder `src/app/interfaces/analysis-store` with the following files describing validation payloads, resource DTOs and upsert payloads: `analysis-store-shared.interface.ts`, `analysis-store-timeline.interface.ts`, `analysis-store-panel.interface.ts`, `analysis-store-imports.interface.ts`, and `index.ts`.
- Implemented a typed API client `AnalysisStoreApi` at `src/app/core/api/analysis-store.api.ts` that exposes: import validation (`validateTimelineImport` / `validatePanelImport`), list/get/export/create/update/delete for `timelines` and `panels`, `copyPanel`, and `upsertTimeline` / `upsertPanel` helper behavior (create when `id` is absent, update when `id` present).
- Extended environment and runtime config to include `analysisStoreEndpoints` in `src/environments/environment*.ts` and `src/environments/environment.model.ts`, and to support SSR/runtime overrides via `ANALYSIS_STORE_API_PREFIX` and per-endpoint env vars in `src/app/core/config/runtime-environment.ts` so local front + dockerized back use cases are supported.
- Kept this change limited to types, environment configuration and the HTTP client only; no UI buttons, modals, actions, effects or reducers were introduced in this change.

### Testing
- Ran `npm run lint` and all files passed linting (`✅`).
- Ran `npm run build` and the build completed successfullly and produced `dist/front-service` (`✅`), however existing SSR prerender logs about `getBoundingClientRect is not a function` were present during prerender and are unrelated to these changes (no DOM/SSR changes were introduced).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db651810348326b2c1c50416b26c78)