### PR TITLE
feat(store): add analysis-store mappers and base NgRx save/load flows

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -10,9 +10,11 @@ import { provideEffects } from '@ngrx/effects';
 import { dataStateReducer } from './store/Data/dataState.reducers';
 import { DataEffects } from './store/Data/dataState.effects';
 import { timelineReducer } from './store/Timeline/timeline.reducer';
+import { analysisStoreReducer } from './store/AnalysisStore/analysis-store.reducer';
 import { jwtInterceptor } from './core/interceptors/jwt.interceptor';
 import { refreshInterceptor } from './core/interceptors/refresh.interceptor';
 import { provideAuthBootstrap } from './core/auth/auth.bootstrap';
+import { AnalysisStoreEffects } from './store/AnalysisStore/analysis-store.effects';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -23,8 +25,9 @@ export const appConfig: ApplicationConfig = {
     provideStore({
       dataState: dataStateReducer,
       timelineState: timelineReducer,
+      analysisStoreState: analysisStoreReducer,
     }),
-    provideEffects(DataEffects),
+    provideEffects(DataEffects, AnalysisStoreEffects),
     provideHttpClient(withInterceptors([jwtInterceptor, refreshInterceptor])),
     provideAuthBootstrap(),
   ],

--- a/src/app/core/api/analysis-store.api.ts
+++ b/src/app/core/api/analysis-store.api.ts
@@ -44,7 +44,11 @@ export class AnalysisStoreApi {
   }
 
   upsertTimeline(payload: UpsertTimelineResourceBody): Observable<TimelineResourceResponse> {
-    return payload.id ? this.updateTimeline(payload.id, payload) : this.createTimeline(payload);
+    if (payload.id) {
+      return this.updateTimeline(payload.id, payload);
+    }
+
+    return this.createTimeline(payload as CreateTimelineResourceBody);
   }
 
   createTimeline(payload: CreateTimelineResourceBody): Observable<TimelineResourceResponse> {
@@ -72,7 +76,11 @@ export class AnalysisStoreApi {
   }
 
   upsertPanel(payload: UpsertPanelResourceBody): Observable<PanelResourceResponse> {
-    return payload.id ? this.updatePanel(payload.id, payload) : this.createPanel(payload);
+    if (payload.id) {
+      return this.updatePanel(payload.id, payload);
+    }
+
+    return this.createPanel(payload as CreatePanelResourceBody);
   }
 
   createPanel(payload: CreatePanelResourceBody): Observable<PanelResourceResponse> {

--- a/src/app/core/mappers/analysis-store/panel-analysis-store.mapper.ts
+++ b/src/app/core/mappers/analysis-store/panel-analysis-store.mapper.ts
@@ -1,0 +1,163 @@
+import { SequencerPanelV1 } from '../../../interfaces/analysis-store';
+import { SequencerPanel } from '../../../interfaces/sequencer-panel.interface';
+import {
+  EventBtn,
+  LabelBtn,
+  SequencerBtn,
+  SequencerStatDefinition,
+  SequencerStatEditorTerm,
+  SequencerStatExpressionToken,
+  StatBtn,
+} from '../../../interfaces/sequencer-btn.interface';
+
+const ANALYSIS_STORE_SCHEMA_VERSION = '1.0.0' as const;
+const SOURCE_APP = 'front-service';
+const SOURCE_APP_VERSION = 'unknown';
+
+export function mapPanelStateToSequencerPanelV1(panel: SequencerPanel): SequencerPanelV1 {
+  const nowIso = new Date().toISOString();
+
+  return {
+    schemaVersion: ANALYSIS_STORE_SCHEMA_VERSION,
+    type: 'sequencer-panel',
+    panelName: panel.panelName?.trim() || 'My Panel',
+    meta: {
+      createdAtIso: nowIso,
+      updatedAtIso: nowIso,
+      exportedAtIso: nowIso,
+      sourceUserId: null,
+      sourceApp: SOURCE_APP,
+      sourceAppVersion: SOURCE_APP_VERSION,
+    },
+    btnList: panel.btnList.map(btn => ({
+      ...mapCommonButtonFields(btn),
+      ...(btn.type === 'event'
+        ? {
+            type: 'event' as const,
+            eventProps: {
+              eventName: btn.name,
+              colorHex: btn.colorHex ?? null,
+            },
+          }
+        : btn.type === 'label'
+          ? {
+              type: 'label' as const,
+              labelProps: {
+                label: btn.name,
+                colorHex: null,
+              },
+            }
+          : {
+              type: 'stat' as const,
+              stat: {
+                statName: btn.name,
+                value: extractStatNumericValue(btn.stat),
+                colorHex: btn.colorHex ?? null,
+              },
+            }),
+    })),
+  };
+}
+
+export function mapSequencerPanelV1ToPanelState(payload: SequencerPanelV1): SequencerPanel {
+  return {
+    panelName: payload.panelName?.trim() || 'My Panel',
+    btnList: payload.btnList.map(btn => {
+      if (btn.type === 'event') {
+        const eventBtn: EventBtn = {
+          type: 'event',
+          id: btn.id,
+          name: btn.name,
+          hotkeyNormalized: btn.hotkeyNormalized,
+          deactivateIds: btn.deactivateIds,
+          activateIds: btn.activateIds,
+          layout: btn.layout,
+          colorHex: btn.eventProps.colorHex ?? undefined,
+          eventProps: {
+            kind: 'limited',
+            preMs: 0,
+            postMs: 0,
+          },
+        };
+
+        return eventBtn;
+      }
+
+      if (btn.type === 'label') {
+        const labelBtn: LabelBtn = {
+          type: 'label',
+          id: btn.id,
+          name: btn.name,
+          hotkeyNormalized: btn.hotkeyNormalized,
+          deactivateIds: btn.deactivateIds,
+          activateIds: btn.activateIds,
+          layout: btn.layout,
+          labelProps: {
+            mode: 'once',
+          },
+        };
+
+        return labelBtn;
+      }
+
+      const statBtn: StatBtn = {
+        type: 'stat',
+        id: btn.id,
+        name: btn.name,
+        hotkeyNormalized: btn.hotkeyNormalized,
+        deactivateIds: btn.deactivateIds,
+        activateIds: btn.activateIds,
+        layout: btn.layout,
+        colorHex: btn.stat.colorHex ?? undefined,
+        stat: createStatFromLegacyValue(btn.stat.value),
+      };
+
+      return statBtn;
+    }),
+  };
+}
+
+function mapCommonButtonFields(btn: SequencerBtn) {
+  return {
+    id: btn.id,
+    name: btn.name,
+    layout: { ...(btn.layout ?? { x: 16, y: 16, w: 240, h: 120 }), z: btn.layout?.z ?? 1 },
+    hotkeyNormalized: btn.hotkeyNormalized ?? null,
+    deactivateIds: btn.deactivateIds ?? [],
+    activateIds: btn.activateIds ?? [],
+  };
+}
+
+function extractStatNumericValue(definition: SequencerStatDefinition): number {
+  if (definition.mode === 'complex' && definition.expression.kind === 'constant') {
+    return definition.expression.value;
+  }
+
+  return 0;
+}
+
+function createStatFromLegacyValue(value: number): SequencerStatDefinition {
+  const normalizedValue = Number.isFinite(value) ? value : 0;
+  const termId = 'legacy_constant';
+  const terms: SequencerStatEditorTerm[] = [
+    {
+      id: termId,
+      displayName: 'Legacy Value',
+      kind: 'constant',
+      constantValue: normalizedValue,
+    },
+  ];
+  const tokens: SequencerStatExpressionToken[] = [{ kind: 'term', termId }];
+
+  return {
+    mode: 'complex',
+    expression: {
+      kind: 'constant',
+      value: normalizedValue,
+    },
+    editor: {
+      terms,
+      tokens,
+    },
+  };
+}

--- a/src/app/core/mappers/analysis-store/timeline-analysis-store.mapper.ts
+++ b/src/app/core/mappers/analysis-store/timeline-analysis-store.mapper.ts
@@ -1,0 +1,111 @@
+import { AnalysisTimelineV1 } from '../../../interfaces/analysis-store';
+import { TIMELINE_DEFAULT_POST_MS, TIMELINE_DEFAULT_PRE_MS } from '../../../interfaces/timeline/timeline-defaults.constants';
+import { TimelineDocument, TimelineMetadata, TimelineOccurrence } from '../../../interfaces/timeline/timeline.interface';
+import { TimelineState } from '../../../store/Timeline/timeline.reducer';
+
+const ANALYSIS_STORE_SCHEMA_VERSION = '1.0.0' as const;
+const SOURCE_APP = 'front-service';
+const SOURCE_APP_VERSION = 'unknown';
+
+export function mapTimelineStateToAnalysisTimelineV1(timelineState: TimelineState): AnalysisTimelineV1 {
+  const nowIso = new Date().toISOString();
+
+  return {
+    schemaVersion: ANALYSIS_STORE_SCHEMA_VERSION,
+    type: 'analysis-timeline',
+    timelineName: timelineState.meta.timelineName?.trim() || 'Timeline',
+    meta: {
+      createdAtIso: timelineState.meta.createdAtIso,
+      updatedAtIso: timelineState.meta.updatedAtIso,
+      exportedAtIso: nowIso,
+      sourceUserId: timelineState.meta.userId ?? null,
+      sourceApp: timelineState.meta.analysisName || SOURCE_APP,
+      sourceAppVersion: SOURCE_APP_VERSION,
+    },
+    eventDefs: timelineState.definitions.eventDefs.map(definition => ({
+      id: definition.id,
+      name: definition.name,
+      colorHex: definition.colorHex ?? null,
+    })),
+    labelDefs: timelineState.definitions.labelDefs.map(definition => ({
+      id: definition.id,
+      name: definition.name,
+      colorHex: null,
+    })),
+    occurrences: timelineState.occurrences.map(occurrence => mapOccurrenceToV1(occurrence)),
+    ui: {
+      zoom: 1,
+      showLabels: true,
+      selectedOccurrenceId: timelineState.ui.selectedOccurrenceIds[0] ?? null,
+    },
+  };
+}
+
+export function mapAnalysisTimelineV1ToTimelineDocument(payload: AnalysisTimelineV1): TimelineDocument {
+  const fallbackNow = new Date().toISOString();
+  const metadata: TimelineMetadata = {
+    timelineName: payload.timelineName?.trim() || 'Timeline',
+    analysisName: payload.meta.sourceApp || 'Analyse locale',
+    createdAtIso: payload.meta.createdAtIso || fallbackNow,
+    updatedAtIso: payload.meta.updatedAtIso || fallbackNow,
+    userId: payload.meta.sourceUserId || 'local-user',
+  };
+
+  return {
+    schemaVersion: payload.schemaVersion,
+    meta: metadata,
+    definitions: {
+      eventDefs: payload.eventDefs.map(definition => ({
+        id: definition.id,
+        sourceSequencerBtnId: definition.id,
+        name: definition.name,
+        colorHex: definition.colorHex ?? undefined,
+        timingMode: 'once',
+        preMs: TIMELINE_DEFAULT_PRE_MS,
+        postMs: TIMELINE_DEFAULT_POST_MS,
+      })),
+      labelDefs: payload.labelDefs.map(definition => ({
+        id: definition.id,
+        sourceSequencerBtnId: definition.id,
+        name: definition.name,
+        behavior: 'once',
+      })),
+    },
+    occurrences: payload.occurrences.map(occurrence => {
+      const startMs = parseMsFromIso(occurrence.occurredAtIso);
+      const durationMs = Math.max(0, occurrence.durationMs || 0);
+
+      return {
+        id: occurrence.id,
+        eventDefId: occurrence.eventDefId || 'unknown-event',
+        startMs,
+        endMs: startMs + durationMs,
+        labelIds: occurrence.labelDefId ? [occurrence.labelDefId] : [],
+        createdAtIso: occurrence.occurredAtIso,
+        updatedAtIso: occurrence.occurredAtIso,
+      };
+    }),
+    ui: {
+      scrollX: 0,
+      scrollY: 0,
+      autoFollow: true,
+      selectedOccurrenceIds: payload.ui.selectedOccurrenceId ? [payload.ui.selectedOccurrenceId] : [],
+    },
+  };
+}
+
+function mapOccurrenceToV1(occurrence: TimelineOccurrence) {
+  return {
+    id: occurrence.id,
+    eventDefId: occurrence.eventDefId,
+    labelDefId: occurrence.labelIds[0] ?? null,
+    occurredAtIso: new Date(occurrence.startMs).toISOString(),
+    durationMs: Math.max(0, occurrence.endMs - occurrence.startMs),
+    note: null,
+  };
+}
+
+function parseMsFromIso(iso: string): number {
+  const parsed = Date.parse(iso);
+  return Number.isFinite(parsed) ? parsed : 0;
+}

--- a/src/app/store/AnalysisStore/analysis-store.actions.ts
+++ b/src/app/store/AnalysisStore/analysis-store.actions.ts
@@ -1,0 +1,85 @@
+import { createAction, props } from '@ngrx/store';
+import {
+  AnalysisStoreVisibility,
+  AnalysisTimelineV1,
+  PanelResourceResponse,
+  SequencerPanelV1,
+  TimelineResourceResponse,
+} from '../../interfaces/analysis-store';
+import { SequencerPanel } from '../../interfaces/sequencer-panel.interface';
+
+export interface SaveAnalysisStorePanelPayload {
+  id?: string;
+  title?: string;
+  description?: string | null;
+  visibility?: AnalysisStoreVisibility;
+  clubId?: string | null;
+  hasAnonymizedContent?: boolean;
+}
+
+export interface SaveAnalysisStoreTimelinePayload {
+  id?: string;
+  title?: string;
+  description?: string | null;
+  hasAnonymizedContent?: boolean;
+}
+
+export interface AnalysisStoreLoadResourceContext {
+  resourceId?: string | null;
+  title?: string;
+  description?: string | null;
+  visibility?: AnalysisStoreVisibility;
+  clubId?: string | null;
+  hasAnonymizedContent?: boolean;
+}
+
+export const analysisStoreSetCurrentPanel = createAction(
+  '[Analysis Store] Set Current Panel',
+  props<{ panel: SequencerPanel }>(),
+);
+
+export const analysisStoreLoadPanelFromValidatedPayload = createAction(
+  '[Analysis Store] Load Panel From Validated Payload',
+  props<{ payload: SequencerPanelV1; context?: AnalysisStoreLoadResourceContext }>(),
+);
+
+export const analysisStoreHydratePanelFromValidatedPayload = createAction(
+  '[Analysis Store] Hydrate Panel From Validated Payload',
+  props<{ panel: SequencerPanel; context?: AnalysisStoreLoadResourceContext }>(),
+);
+
+export const analysisStoreLoadTimelineFromValidatedPayload = createAction(
+  '[Analysis Store] Load Timeline From Validated Payload',
+  props<{ payload: AnalysisTimelineV1; context?: AnalysisStoreLoadResourceContext }>(),
+);
+
+export const analysisStoreHydrateTimelineResourceMeta = createAction(
+  '[Analysis Store] Hydrate Timeline Resource Meta',
+  props<{ timeline: AnalysisTimelineV1; context?: AnalysisStoreLoadResourceContext }>(),
+);
+
+export const analysisStoreSavePanel = createAction(
+  '[Analysis Store] Save Panel',
+  props<{ payload?: SaveAnalysisStorePanelPayload }>(),
+);
+export const analysisStoreSavePanelSuccess = createAction(
+  '[Analysis Store] Save Panel Success',
+  props<{ resource: PanelResourceResponse }>(),
+);
+export const analysisStoreSavePanelFailure = createAction(
+  '[Analysis Store] Save Panel Failure',
+  props<{ error: string }>(),
+);
+
+export const analysisStoreSaveTimeline = createAction(
+  '[Analysis Store] Save Timeline',
+  props<{ payload?: SaveAnalysisStoreTimelinePayload }>(),
+);
+export const analysisStoreSaveTimelineSuccess = createAction(
+  '[Analysis Store] Save Timeline Success',
+  props<{ resource: TimelineResourceResponse }>(),
+);
+export const analysisStoreSaveTimelineFailure = createAction(
+  '[Analysis Store] Save Timeline Failure',
+  props<{ error: string }>(),
+);

--- a/src/app/store/AnalysisStore/analysis-store.effects.ts
+++ b/src/app/store/AnalysisStore/analysis-store.effects.ts
@@ -1,0 +1,119 @@
+import { Injectable, inject } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Store } from '@ngrx/store';
+import { catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
+import { AnalysisStoreApi } from '../../core/api/analysis-store.api';
+import {
+  mapPanelStateToSequencerPanelV1,
+  mapSequencerPanelV1ToPanelState,
+} from '../../core/mappers/analysis-store/panel-analysis-store.mapper';
+import {
+  mapAnalysisTimelineV1ToTimelineDocument,
+  mapTimelineStateToAnalysisTimelineV1,
+} from '../../core/mappers/analysis-store/timeline-analysis-store.mapper';
+import { initTimeline } from '../Timeline/timeline.actions';
+import { selectTimelineState } from '../Timeline/timeline.selectors';
+import {
+  analysisStoreHydratePanelFromValidatedPayload,
+  analysisStoreHydrateTimelineResourceMeta,
+  analysisStoreLoadPanelFromValidatedPayload,
+  analysisStoreLoadTimelineFromValidatedPayload,
+  analysisStoreSavePanel,
+  analysisStoreSavePanelFailure,
+  analysisStoreSavePanelSuccess,
+  analysisStoreSaveTimeline,
+  analysisStoreSaveTimelineFailure,
+  analysisStoreSaveTimelineSuccess,
+} from './analysis-store.actions';
+import { selectAnalysisStorePanelState, selectAnalysisStoreTimelineState } from './analysis-store.selectors';
+
+@Injectable()
+export class AnalysisStoreEffects {
+  private readonly actions$ = inject(Actions);
+  private readonly store = inject(Store);
+  private readonly analysisStoreApi = inject(AnalysisStoreApi);
+
+  readonly savePanel$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreSavePanel),
+      withLatestFrom(this.store.select(selectAnalysisStorePanelState)),
+      switchMap(([action, panelState]) => {
+        if (!panelState.currentContent) {
+          return of(analysisStoreSavePanelFailure({ error: 'No panel content to save.' }));
+        }
+
+        const mappedPanel = mapPanelStateToSequencerPanelV1(panelState.currentContent);
+        const payload = {
+          id: action.payload?.id ?? panelState.currentResourceId ?? undefined,
+          title: action.payload?.title ?? panelState.title ?? mappedPanel.panelName,
+          description: action.payload?.description ?? panelState.description,
+          visibility: action.payload?.visibility ?? panelState.visibility,
+          clubId: action.payload?.clubId ?? panelState.clubId,
+          hasAnonymizedContent: action.payload?.hasAnonymizedContent ?? panelState.hasAnonymizedContent,
+          contentJson: mappedPanel as unknown as Record<string, unknown>,
+        };
+
+        return this.analysisStoreApi.upsertPanel(payload).pipe(
+          map(resource => analysisStoreSavePanelSuccess({ resource })),
+          catchError(error => of(analysisStoreSavePanelFailure({ error: error?.message ?? 'Panel save failed' }))),
+        );
+      }),
+    ),
+  );
+
+  readonly saveTimeline$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreSaveTimeline),
+      withLatestFrom(this.store.select(selectTimelineState), this.store.select(selectAnalysisStoreTimelineState)),
+      switchMap(([action, timelineState, resourceMeta]) => {
+        const mappedTimeline = mapTimelineStateToAnalysisTimelineV1(timelineState);
+        const payload = {
+          id: action.payload?.id ?? resourceMeta.currentResourceId ?? undefined,
+          title: action.payload?.title ?? resourceMeta.title ?? mappedTimeline.timelineName,
+          description: action.payload?.description ?? resourceMeta.description,
+          hasAnonymizedContent: action.payload?.hasAnonymizedContent ?? resourceMeta.hasAnonymizedContent,
+          contentJson: mappedTimeline as unknown as Record<string, unknown>,
+        };
+
+        return this.analysisStoreApi.upsertTimeline(payload).pipe(
+          map(resource => analysisStoreSaveTimelineSuccess({ resource })),
+          catchError(error => of(analysisStoreSaveTimelineFailure({ error: error?.message ?? 'Timeline save failed' }))),
+        );
+      }),
+    ),
+  );
+
+  readonly loadPanelFromValidatedPayload$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreLoadPanelFromValidatedPayload),
+      map(({ payload, context }) =>
+        analysisStoreHydratePanelFromValidatedPayload({
+          panel: mapSequencerPanelV1ToPanelState(payload),
+          context,
+        }),
+      ),
+    ),
+  );
+
+  readonly loadTimelineFromValidatedPayload$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreLoadTimelineFromValidatedPayload),
+      map(({ payload }) => {
+        const mappedTimeline = mapAnalysisTimelineV1ToTimelineDocument(payload);
+        return initTimeline({
+          schemaVersion: mappedTimeline.schemaVersion,
+          meta: mappedTimeline.meta,
+          definitions: mappedTimeline.definitions,
+          occurrences: mappedTimeline.occurrences,
+        });
+      }),
+    ),
+  );
+
+  readonly hydrateTimelineMetaFromValidatedPayload$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreLoadTimelineFromValidatedPayload),
+      map(({ payload, context }) => analysisStoreHydrateTimelineResourceMeta({ timeline: payload, context })),
+    ),
+  );
+}

--- a/src/app/store/AnalysisStore/analysis-store.reducer.ts
+++ b/src/app/store/AnalysisStore/analysis-store.reducer.ts
@@ -1,0 +1,165 @@
+import { createReducer, on } from '@ngrx/store';
+import { AnalysisStoreVisibility, PanelResourceResponse, TimelineResourceResponse } from '../../interfaces/analysis-store';
+import { SequencerPanel } from '../../interfaces/sequencer-panel.interface';
+import {
+  analysisStoreHydratePanelFromValidatedPayload,
+  analysisStoreHydrateTimelineResourceMeta,
+  analysisStoreSavePanel,
+  analysisStoreSavePanelFailure,
+  analysisStoreSavePanelSuccess,
+  analysisStoreSaveTimeline,
+  analysisStoreSaveTimelineFailure,
+  analysisStoreSaveTimelineSuccess,
+  analysisStoreSetCurrentPanel,
+} from './analysis-store.actions';
+
+export interface AnalysisStoreResourceMetaState {
+  currentResourceId: string | null;
+  title: string;
+  description: string | null;
+  visibility: AnalysisStoreVisibility;
+  clubId: string | null;
+  hasAnonymizedContent: boolean;
+  lastSavedAt: string | null;
+}
+
+export interface AnalysisStoreState {
+  panel: AnalysisStoreResourceMetaState & {
+    currentContent: SequencerPanel | null;
+    isSaving: boolean;
+    error: string | null;
+  };
+  timeline: AnalysisStoreResourceMetaState & {
+    isSaving: boolean;
+    error: string | null;
+  };
+}
+
+const initialResourceMetaState: AnalysisStoreResourceMetaState = {
+  currentResourceId: null,
+  title: '',
+  description: null,
+  visibility: 'private',
+  clubId: null,
+  hasAnonymizedContent: false,
+  lastSavedAt: null,
+};
+
+export const initialAnalysisStoreState: AnalysisStoreState = {
+  panel: {
+    ...initialResourceMetaState,
+    title: 'My Panel',
+    currentContent: null,
+    isSaving: false,
+    error: null,
+  },
+  timeline: {
+    ...initialResourceMetaState,
+    title: 'Timeline',
+    isSaving: false,
+    error: null,
+  },
+};
+
+export const analysisStoreReducer = createReducer(
+  initialAnalysisStoreState,
+  on(analysisStoreSetCurrentPanel, (state, { panel }) => ({
+    ...state,
+    panel: {
+      ...state.panel,
+      currentContent: panel,
+      title: panel.panelName?.trim() || state.panel.title,
+    },
+  })),
+  on(analysisStoreHydratePanelFromValidatedPayload, (state, { panel, context }) => ({
+    ...state,
+    panel: {
+      ...state.panel,
+      currentResourceId: context?.resourceId ?? null,
+      title: context?.title ?? panel.panelName ?? 'My Panel',
+      description: context?.description ?? null,
+      visibility: context?.visibility ?? 'private',
+      clubId: context?.clubId ?? null,
+      hasAnonymizedContent: context?.hasAnonymizedContent ?? false,
+      currentContent: panel,
+      error: null,
+    },
+  })),
+  on(analysisStoreHydrateTimelineResourceMeta, (state, { timeline, context }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      currentResourceId: context?.resourceId ?? null,
+      title: context?.title ?? timeline.timelineName ?? 'Timeline',
+      description: context?.description ?? null,
+      visibility: context?.visibility ?? 'private',
+      clubId: context?.clubId ?? null,
+      hasAnonymizedContent: context?.hasAnonymizedContent ?? false,
+      error: null,
+    },
+  })),
+  on(analysisStoreSavePanel, state => ({
+    ...state,
+    panel: {
+      ...state.panel,
+      isSaving: true,
+      error: null,
+    },
+  })),
+  on(analysisStoreSavePanelSuccess, (state, { resource }) => ({
+    ...state,
+    panel: {
+      ...state.panel,
+      ...toResourceMetaState(resource),
+      title: resource.title,
+      isSaving: false,
+      error: null,
+    },
+  })),
+  on(analysisStoreSavePanelFailure, (state, { error }) => ({
+    ...state,
+    panel: {
+      ...state.panel,
+      isSaving: false,
+      error,
+    },
+  })),
+  on(analysisStoreSaveTimeline, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isSaving: true,
+      error: null,
+    },
+  })),
+  on(analysisStoreSaveTimelineSuccess, (state, { resource }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      ...toResourceMetaState(resource),
+      title: resource.title,
+      isSaving: false,
+      error: null,
+    },
+  })),
+  on(analysisStoreSaveTimelineFailure, (state, { error }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isSaving: false,
+      error,
+    },
+  })),
+);
+
+function toResourceMetaState(resource: TimelineResourceResponse | PanelResourceResponse): AnalysisStoreResourceMetaState {
+  return {
+    currentResourceId: resource.id,
+    title: resource.title,
+    description: resource.description,
+    visibility: resource.visibility,
+    clubId: resource.clubId,
+    hasAnonymizedContent: resource.hasAnonymizedContent,
+    lastSavedAt: resource.updatedAt,
+  };
+}

--- a/src/app/store/AnalysisStore/analysis-store.selectors.ts
+++ b/src/app/store/AnalysisStore/analysis-store.selectors.ts
@@ -1,0 +1,28 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { AnalysisStoreState } from './analysis-store.reducer';
+import { selectTimelineOccurrences } from '../Timeline/timeline.selectors';
+
+export const selectAnalysisStoreState = createFeatureSelector<AnalysisStoreState>('analysisStoreState');
+
+export const selectAnalysisStorePanelState = createSelector(selectAnalysisStoreState, state => state.panel);
+export const selectAnalysisStoreTimelineState = createSelector(selectAnalysisStoreState, state => state.timeline);
+
+export const selectCurrentPanelResourceId = createSelector(
+  selectAnalysisStorePanelState,
+  panelState => panelState.currentResourceId,
+);
+
+export const selectCurrentTimelineResourceId = createSelector(
+  selectAnalysisStoreTimelineState,
+  timelineState => timelineState.currentResourceId,
+);
+
+export const selectHasCurrentPanelContent = createSelector(
+  selectAnalysisStorePanelState,
+  panelState => !!panelState.currentContent && panelState.currentContent.btnList.length > 0,
+);
+
+export const selectHasCurrentTimelineContent = createSelector(
+  selectTimelineOccurrences,
+  occurrences => occurrences.length > 0,
+);

--- a/src/app/store/initial-state.state.ts
+++ b/src/app/store/initial-state.state.ts
@@ -1,15 +1,18 @@
 import { DataState, initialDataState } from './Data/dataState.reducers';
 import { UserState, initialUserState } from './User/user.reducer';
 import { TimelineState, initialTimelineState } from './Timeline/timeline.reducer';
+import { AnalysisStoreState, initialAnalysisStoreState } from './AnalysisStore/analysis-store.reducer';
 
 export interface AppState {
   dataState: DataState;
   userState: UserState;
   timelineState: TimelineState;
+  analysisStoreState: AnalysisStoreState;
 }
 
 export const initialAppState: AppState = {
   dataState: initialDataState,
   userState: initialUserState,
   timelineState: initialTimelineState,
+  analysisStoreState: initialAnalysisStoreState,
 };


### PR DESCRIPTION
### Motivation
- Centraliser les conversions front <-> analysis-store (import/export v1) pour panels et timelines afin d'éviter des mappings dispersés dans l'app.
- Fournir une base NgRx (actions → effects → reducer → selectors) pour mémoriser la ressource distante courante (id, titre, description, métadonnées) et gérer les opérations create/update pour panel et timeline.
- Respecter le pattern existant du projet (pas de logique métier lourde dans les composants, mappers dédiés, usage d'effects pour les appels API).

### Description
- Ajout de mappers dédiés `src/app/core/mappers/analysis-store/panel-analysis-store.mapper.ts` et `src/app/core/mappers/analysis-store/timeline-analysis-store.mapper.ts` pour convertir entre le modèle front (`SequencerPanel`, `TimelineState`/`TimelineDocument`) et les payloads `SequencerPanelV1` / `AnalysisTimelineV1`.
- Nouvelle feature store `analysisStoreState` avec actions (`src/app/store/AnalysisStore/analysis-store.actions.ts`), effects (`.../analysis-store.effects.ts`), reducer (`.../analysis-store.reducer.ts`) et selectors (`.../analysis-store.selectors.ts`) pour : charger un payload validé, hydrater la meta ressource, définir le panel courant, et sauvegarder panel/timeline (create si pas d'id, update si id présent).
- Adaptations API et wiring : `AnalysisStoreApi.upsertPanel/upsertTimeline` typage ajusté pour create/update, intégration du reducer et des effects dans `src/app/app.config.ts`, et ajout de l'état initial `analysisStoreState` dans `src/app/store/initial-state.state.ts`.
- Selectors fournis : `selectHasCurrentPanelContent`, `selectHasCurrentTimelineContent`, `selectCurrentPanelResourceId`, `selectCurrentTimelineResourceId` pour piloter l'UI/flow de sauvegarde ou d'écrasement.

### Testing
- Lint exécuté avec `npm run lint` : réussite (tous les fichiers passent le lint).
- Build exécuté avec `npm run build` : réussite (bundle généré); des logs SSR/prerender relatifs à du DOM durante la prerender sont présents mais le build a abouti.
- Aucun test unitaire additionnel n'a été ajouté dans cette PR; la suite de tests unitaires n'a pas été lancée ici.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcad9f07c883268709f91892446149)