### PR TITLE
feat(sequencer): add anonymization option on panel buttons

### DIFF
--- a/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.html
+++ b/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.html
@@ -35,6 +35,12 @@
       <label for="event-color" class="text-xs font-semibold">Couleur</label>
       <input id="event-color" type="color" formControlName="colorHex" class="timeline-color-input" />
     </div>
+    <div class="border-layer rounded-md border p-3">
+      <mat-checkbox formControlName="isAnonymized">Anonymiser ce bouton</mat-checkbox>
+      <p class="text-muted mt-1 text-xs italic">
+        Active l’obfuscation du nom du bouton dans les vues concernées.
+      </p>
+    </div>
 
     @if (isEdit) {
       <div class="border-layer rounded-md border p-3">

--- a/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/event/create-event-btn-dialog.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, computed, inject, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -32,6 +33,7 @@ export interface EventBtnDialogData {
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
+    MatCheckboxModule,
     MatRadioModule,
     MatSelectModule,
     MatIconModule,
@@ -78,6 +80,9 @@ export class CreateEventBtnDialogComponent {
       nonNullable: true,
     }),
     postSec: new FormControl<number>(this.data.btn ? this.data.btn.eventProps.postMs / 1000 : 0, {
+      nonNullable: true,
+    }),
+    isAnonymized: new FormControl<boolean>(this.data.btn?.isAnonymized ?? false, {
       nonNullable: true,
     }),
   });
@@ -142,6 +147,7 @@ export class CreateEventBtnDialogComponent {
     const kind = this.form.controls.kind.value ?? 'limited';
     const preMs = Math.max(0, Math.round((this.form.controls.preSec.value ?? 0) * 1000));
     const postMs = Math.max(0, Math.round((this.form.controls.postSec.value ?? 0) * 1000));
+    const isAnonymized = this.form.controls.isAnonymized.value ?? false;
 
     const chord = this.selectedChord();
     let hotkeyNormalized: string | null = null;
@@ -170,6 +176,7 @@ export class CreateEventBtnDialogComponent {
         name,
         colorHex,
         hotkeyNormalized,
+        isAnonymized,
         deactivateIds,
         activateIds,
         eventProps: { kind, preMs, postMs },
@@ -180,6 +187,7 @@ export class CreateEventBtnDialogComponent {
         name,
         colorHex,
         hotkeyNormalized,
+        isAnonymized,
         deactivateIds,
         activateIds,
         eventProps: { kind, preMs, postMs },

--- a/src/app/components/analyse/sequencer/createBtn/label/create-label-btn-dialog.component.html
+++ b/src/app/components/analyse/sequencer/createBtn/label/create-label-btn-dialog.component.html
@@ -19,6 +19,12 @@
         <input matInput formControlName="name" />
       </mat-form-field>
     </div>
+    <div class="border-layer rounded-md border p-3">
+      <mat-checkbox formControlName="isAnonymized">Anonymiser ce bouton</mat-checkbox>
+      <p class="text-muted mt-1 text-xs italic">
+        Active l’obfuscation du nom du bouton dans les vues concernées.
+      </p>
+    </div>
 
     @if (isEdit) {
       <div class="border-layer rounded-md border p-3">

--- a/src/app/components/analyse/sequencer/createBtn/label/create-label-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/label/create-label-btn-dialog.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component, computed, inject, signal } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -31,6 +32,7 @@ export interface LabelBtnDialogData {
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
+    MatCheckboxModule,
     MatRadioModule,
     MatSelectModule,
     MatIconModule,
@@ -70,6 +72,9 @@ export class CreateLabelBtnDialogComponent {
     ),
     name: new FormControl(this.data.btn?.name ?? '', [Validators.required]),
     mode: new FormControl<'once' | 'indefinite'>(this.data.btn?.labelProps.mode ?? 'once', {
+      nonNullable: true,
+    }),
+    isAnonymized: new FormControl<boolean>(this.data.btn?.isAnonymized ?? false, {
       nonNullable: true,
     }),
   });
@@ -131,6 +136,7 @@ export class CreateLabelBtnDialogComponent {
     const id = (this.form.controls.id.value ?? '').trim();
     const name = (this.form.controls.name.value ?? '').trim();
     const mode = this.form.controls.mode.value ?? 'once';
+    const isAnonymized = this.form.controls.isAnonymized.value ?? false;
 
     const chord = this.selectedChord();
     let hotkeyNormalized: string | null = null;
@@ -158,6 +164,7 @@ export class CreateLabelBtnDialogComponent {
       this.panelService.updateBtn(id, {
         name,
         hotkeyNormalized,
+        isAnonymized,
         deactivateIds,
         activateIds,
         labelProps: { mode },
@@ -167,6 +174,7 @@ export class CreateLabelBtnDialogComponent {
         id,
         name,
         hotkeyNormalized,
+        isAnonymized,
         deactivateIds,
         activateIds,
         labelProps: { mode },

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.html
@@ -14,6 +14,12 @@
         <input matInput formControlName="name" />
       </mat-form-field>
     </div>
+    <div class="border-layer rounded-md border p-3">
+      <mat-checkbox formControlName="isAnonymized">Anonymiser ce bouton</mat-checkbox>
+      <p class="text-muted mt-1 text-xs italic">
+        Active l’obfuscation du nom du bouton dans les vues concernées.
+      </p>
+    </div>
 
     <div class="border-layer rounded-md border p-3">
       <div class="mb-2 text-[13px] font-semibold">Couleur du bouton</div>

--- a/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.ts
@@ -3,6 +3,7 @@ import { Component, computed, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { AbstractControl, FormControl, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
@@ -46,6 +47,7 @@ export interface StatBtnDialogData {
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
+    MatCheckboxModule,
     MatRadioModule,
     MatSelectModule,
     MatIconModule,
@@ -69,6 +71,9 @@ export class CreateStatBtnDialogComponent {
     colorHex: new FormControl(normalizeColor(this.data.btn?.colorHex), {
       nonNullable: true,
       validators: [Validators.required, Validators.pattern(/^#[0-9a-fA-F]{6}$/)],
+    }),
+    isAnonymized: new FormControl(this.data.btn?.isAnonymized ?? false, {
+      nonNullable: true,
     }),
   });
 
@@ -272,6 +277,7 @@ export class CreateStatBtnDialogComponent {
     const id = this.form.controls.id.value.trim();
     const name = this.form.controls.name.value.trim();
     const colorHex = normalizeColor(this.form.controls.colorHex.value);
+    const isAnonymized = this.form.controls.isAnonymized.value;
 
     const statDefinition = this.modeValue() === 'simple'
       ? this.buildSimpleDefinition()
@@ -282,9 +288,9 @@ export class CreateStatBtnDialogComponent {
     }
 
     if (this.isEdit) {
-      this.panelService.updateBtn(id, { name, colorHex, stat: statDefinition });
+      this.panelService.updateBtn(id, { name, colorHex, isAnonymized, stat: statDefinition });
     } else {
-      this.panelService.addStatBtn({ id, name, colorHex, stat: statDefinition });
+      this.panelService.addStatBtn({ id, name, colorHex, isAnonymized, stat: statDefinition });
     }
 
     this.dialogRef.close(true);

--- a/src/app/core/mappers/analysis-store/panel-analysis-store.mapper.ts
+++ b/src/app/core/mappers/analysis-store/panel-analysis-store.mapper.ts
@@ -68,6 +68,7 @@ export function mapSequencerPanelV1ToPanelState(payload: SequencerPanelV1): Sequ
           type: 'event',
           id: btn.id,
           name: btn.name,
+          isAnonymized: !!btn.isAnonymized,
           hotkeyNormalized: btn.hotkeyNormalized,
           deactivateIds: btn.deactivateIds,
           activateIds: btn.activateIds,
@@ -88,6 +89,7 @@ export function mapSequencerPanelV1ToPanelState(payload: SequencerPanelV1): Sequ
           type: 'label',
           id: btn.id,
           name: btn.name,
+          isAnonymized: !!btn.isAnonymized,
           hotkeyNormalized: btn.hotkeyNormalized,
           deactivateIds: btn.deactivateIds,
           activateIds: btn.activateIds,
@@ -104,6 +106,7 @@ export function mapSequencerPanelV1ToPanelState(payload: SequencerPanelV1): Sequ
         type: 'stat',
         id: btn.id,
         name: btn.name,
+        isAnonymized: !!btn.isAnonymized,
         hotkeyNormalized: btn.hotkeyNormalized,
         deactivateIds: btn.deactivateIds,
         activateIds: btn.activateIds,
@@ -121,11 +124,16 @@ function mapCommonButtonFields(btn: SequencerBtn) {
   return {
     id: btn.id,
     name: btn.name,
+    isAnonymized: !!btn.isAnonymized,
     layout: { ...(btn.layout ?? { x: 16, y: 16, w: 240, h: 120 }), z: btn.layout?.z ?? 1 },
     hotkeyNormalized: btn.hotkeyNormalized ?? null,
     deactivateIds: btn.deactivateIds ?? [],
     activateIds: btn.activateIds ?? [],
   };
+}
+
+export function hasAnonymizedButtons(panel: SequencerPanel): boolean {
+  return panel.btnList.some(btn => !!btn.isAnonymized);
 }
 
 function extractStatNumericValue(definition: SequencerStatDefinition): number {

--- a/src/app/interfaces/analysis-store/analysis-store-panel.interface.ts
+++ b/src/app/interfaces/analysis-store/analysis-store-panel.interface.ts
@@ -17,6 +17,7 @@ export interface SequencerPanelLayoutV1 {
 export interface SequencerPanelBtnBaseV1 {
   id: string;
   name: string;
+  isAnonymized?: boolean;
   layout: SequencerPanelLayoutV1;
   hotkeyNormalized: string | null;
   deactivateIds: string[];

--- a/src/app/interfaces/sequencer-btn.interface.ts
+++ b/src/app/interfaces/sequencer-btn.interface.ts
@@ -53,6 +53,7 @@ export interface SequencerBtnBase {
   id: string;
   name: string;
   type: 'event' | 'label' | 'stat';
+  isAnonymized?: boolean;
   hotkeyNormalized?: string | null;
   deactivateIds?: string[];
   activateIds?: string[];

--- a/src/app/store/AnalysisStore/analysis-store.effects.ts
+++ b/src/app/store/AnalysisStore/analysis-store.effects.ts
@@ -4,6 +4,7 @@ import { Store } from '@ngrx/store';
 import { catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
 import { AnalysisStoreApi } from '../../core/api/analysis-store.api';
 import {
+  hasAnonymizedButtons,
   mapPanelStateToSequencerPanelV1,
   mapSequencerPanelV1ToPanelState,
 } from '../../core/mappers/analysis-store/panel-analysis-store.mapper';
@@ -43,13 +44,14 @@ export class AnalysisStoreEffects {
         }
 
         const mappedPanel = mapPanelStateToSequencerPanelV1(panelState.currentContent);
+        const hasAnonymizedContent = hasAnonymizedButtons(panelState.currentContent);
         const payload = {
           id: action.payload?.id ?? panelState.currentResourceId ?? undefined,
           title: action.payload?.title ?? panelState.title ?? mappedPanel.panelName,
           description: action.payload?.description ?? panelState.description,
           visibility: action.payload?.visibility ?? panelState.visibility,
           clubId: action.payload?.clubId ?? panelState.clubId,
-          hasAnonymizedContent: action.payload?.hasAnonymizedContent ?? panelState.hasAnonymizedContent,
+          hasAnonymizedContent,
           contentJson: mappedPanel as unknown as Record<string, unknown>,
         };
 


### PR DESCRIPTION
### Motivation
- Introduire la notion d’anonymisation au niveau des boutons du panneau pour permettre l’obfuscation des noms dans les vues concernées et remonter un flag `hasAnonymizedContent` cohérent lors de la sauvegarde vers analysis-store.
- Automatiser le calcul de `hasAnonymizedContent` en se basant sur les boutons du panel pour éviter la saisie manuelle et garantir la cohérence owner / redacted décrite dans le contrat analysis-store.

### Description
- Ajout du champ `isAnonymized?: boolean` dans le modèle front `SequencerBtnBase` et dans le DTO panel analysis-store `SequencerPanelBtnBaseV1` pour porter l’option par bouton. 
- Mappers panel mis à jour pour sérialiser / désérialiser `isAnonymized` sur les boutons `event`, `label` et `stat`, et ajout d’un helper `hasAnonymizedButtons(panel)` exposant la règle métier. 
- L’effect NgRx de sauvegarde panel (`analysisStoreSavePanel`) calcule automatiquement `hasAnonymizedContent` avant l’appel API via `hasAnonymizedButtons(panel)` et inclut la valeur dans le `payload` envoyé à `upsertPanel`. 
- UI: ajout d’une case à cocher `Anonymiser ce bouton` et d’une ligne d’aide en italique dans les modales de création/édition `CreateEventBtnDialog`, `CreateLabelBtnDialog` et `CreateStatBtnDialog`, avec propagation du champ `isAnonymized` vers `SequencerPanelService.add*/updateBtn`.

### Testing
- `npm run lint` executed and passed with no lint errors. 
- Unit tests were attempted with `npm run test -- --watch=false --browsers=ChromeHeadless --include src/app/components/analyse/sequencer/createBtn/stat/create-stat-btn-dialog.component.spec.ts` but the run failed during compilation due to an unrelated environment typing issue (`Cannot find name 'process'` in `runtime-environment.ts`), not caused by these changes. 
- No UI/regression failures observed locally for modified dialogs via static inspection and unit test scaffolding; changes are limited to adding an optional boolean and wiring it through existing flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb380179483268ed8ca843b030650)