### PR TITLE
feat(sequencer): connect panel import/export/save/publish flows

### DIFF
--- a/src/app/components/analyse/sequencer/modals/panel-description-dialog/panel-description-dialog.component.html
+++ b/src/app/components/analyse/sequencer/modals/panel-description-dialog/panel-description-dialog.component.html
@@ -1,0 +1,19 @@
+<h2 mat-dialog-title>Éditer la description</h2>
+
+<mat-dialog-content>
+  <mat-form-field appearance="outline" class="w-full">
+    <mat-label>Description</mat-label>
+    <textarea
+      matInput
+      rows="5"
+      [ngModel]="description()"
+      (ngModelChange)="description.set($event)"
+      placeholder="Ajouter une description"
+    ></textarea>
+  </mat-form-field>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="close()">Annuler</button>
+  <button mat-flat-button color="primary" type="button" (click)="submit()">Enregistrer</button>
+</mat-dialog-actions>

--- a/src/app/components/analyse/sequencer/modals/panel-description-dialog/panel-description-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/modals/panel-description-dialog/panel-description-dialog.component.ts
@@ -1,0 +1,37 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+export interface PanelDescriptionDialogData {
+  description: string | null;
+}
+
+export interface PanelDescriptionDialogResult {
+  description: string | null;
+}
+
+@Component({
+  selector: 'app-panel-description-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatDialogModule, MatButtonModule, MatFormFieldModule, MatInputModule],
+  templateUrl: './panel-description-dialog.component.html',
+})
+export class PanelDescriptionDialogComponent {
+  readonly data = inject<PanelDescriptionDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject(MatDialogRef<PanelDescriptionDialogComponent, PanelDescriptionDialogResult | null>);
+
+  readonly description = signal(this.data.description ?? '');
+
+  close() {
+    this.dialogRef.close(null);
+  }
+
+  submit() {
+    const trimmed = this.description().trim();
+    this.dialogRef.close({ description: trimmed ? trimmed : null });
+  }
+}

--- a/src/app/components/analyse/sequencer/modals/panel-publish-dialog/panel-publish-dialog.component.html
+++ b/src/app/components/analyse/sequencer/modals/panel-publish-dialog/panel-publish-dialog.component.html
@@ -1,0 +1,15 @@
+<h2 mat-dialog-title>Publier le panel</h2>
+
+<mat-dialog-content>
+  <p>Choisissez la visibilité de publication.</p>
+
+  <mat-radio-group [ngModel]="visibility()" (ngModelChange)="visibility.set($event)">
+    <mat-radio-button value="public">Public</mat-radio-button>
+    <mat-radio-button value="club" [disabled]="!data.hasClubId">Club</mat-radio-button>
+  </mat-radio-group>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="close()">Annuler</button>
+  <button mat-flat-button color="primary" type="button" (click)="submit()">Publier</button>
+</mat-dialog-actions>

--- a/src/app/components/analyse/sequencer/modals/panel-publish-dialog/panel-publish-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/modals/panel-publish-dialog/panel-publish-dialog.component.ts
@@ -1,0 +1,36 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatRadioModule } from '@angular/material/radio';
+
+export interface PanelPublishDialogData {
+  hasClubId: boolean;
+  currentVisibility: 'private' | 'club' | 'public';
+}
+
+export interface PanelPublishDialogResult {
+  visibility: 'club' | 'public';
+}
+
+@Component({
+  selector: 'app-panel-publish-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatDialogModule, MatButtonModule, MatRadioModule],
+  templateUrl: './panel-publish-dialog.component.html',
+})
+export class PanelPublishDialogComponent {
+  readonly data = inject<PanelPublishDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject(MatDialogRef<PanelPublishDialogComponent, PanelPublishDialogResult | null>);
+
+  readonly visibility = signal<'club' | 'public'>(this.data.currentVisibility === 'club' && this.data.hasClubId ? 'club' : 'public');
+
+  close() {
+    this.dialogRef.close(null);
+  }
+
+  submit() {
+    this.dialogRef.close({ visibility: this.visibility() });
+  }
+}

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.html
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.html
@@ -8,10 +8,26 @@
       <div class="text-muted text-[11px]">Agrandir pour éditer le Sequencer Canvas.</div>
     </div>
     <mat-menu #menu="matMenu">
-      <button mat-menu-item disabled>Export</button>
-      <button mat-menu-item disabled>Import</button>
-      <button mat-menu-item disabled>Save</button>
-      <button mat-menu-item disabled>SeeAllMyPanels</button>
+      <button mat-menu-item type="button" (click)="openEditDescriptionDialog()">
+        <mat-icon aria-hidden="true">description</mat-icon>
+        <span>Description</span>
+      </button>
+      <button mat-menu-item type="button" (click)="exportPanel()">
+        <mat-icon aria-hidden="true">download</mat-icon>
+        <span>Exporter</span>
+      </button>
+      <button mat-menu-item type="button" (click)="triggerImportPanel()">
+        <mat-icon aria-hidden="true">upload_file</mat-icon>
+        <span>Importer</span>
+      </button>
+      <button mat-menu-item type="button" (click)="savePrivatePanel()">
+        <mat-icon aria-hidden="true">save</mat-icon>
+        <span>Sauvegarder</span>
+      </button>
+      <button mat-menu-item type="button" (click)="openPublishDialog()">
+        <mat-icon aria-hidden="true">publish</mat-icon>
+        <span>Publier</span>
+      </button>
     </mat-menu>
   } @else {
     <div class="flex items-center gap-2">
@@ -23,10 +39,26 @@
           <mat-icon aria-hidden="true">edit</mat-icon>
           <span>Renommer</span>
         </button>
-        <button mat-menu-item disabled>Export</button>
-        <button mat-menu-item disabled>Import</button>
-        <button mat-menu-item disabled>Save</button>
-        <button mat-menu-item disabled>SeeAllMyPanels</button>
+        <button mat-menu-item type="button" (click)="openEditDescriptionDialog()">
+          <mat-icon aria-hidden="true">description</mat-icon>
+          <span>Description</span>
+        </button>
+        <button mat-menu-item type="button" (click)="exportPanel()">
+          <mat-icon aria-hidden="true">download</mat-icon>
+          <span>Exporter</span>
+        </button>
+        <button mat-menu-item type="button" (click)="triggerImportPanel()">
+          <mat-icon aria-hidden="true">upload_file</mat-icon>
+          <span>Importer</span>
+        </button>
+        <button mat-menu-item type="button" (click)="savePrivatePanel()">
+          <mat-icon aria-hidden="true">save</mat-icon>
+          <span>Sauvegarder</span>
+        </button>
+        <button mat-menu-item type="button" (click)="openPublishDialog()">
+          <mat-icon aria-hidden="true">publish</mat-icon>
+          <span>Publier</span>
+        </button>
       </mat-menu>
 
       <button type="button" class="seq-btn-event icon p-2" (click)="openEventDialog()" aria-label="Créer un event"
@@ -67,6 +99,10 @@
           <mat-icon aria-hidden="true">lock</mat-icon>
         }
       </button>
+
+      <button type="button" class="icon p-2" (click)="savePrivatePanel()" aria-label="Sauvegarder en privé" title="Sauvegarder">
+        <mat-icon aria-hidden="true">save</mat-icon>
+      </button>
     </div>
   }
 
@@ -81,4 +117,6 @@
       (deleteBtn)="deleteBtn($event)"
     ></app-sequencer-canvas>
   </div>
+
+  <input #panelFileInput type="file" accept="application/json,.json" class="hidden" (change)="onImportPanelFileSelected($event)" />
 </div>

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.ts
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import {
   AfterViewInit,
   Component,
+  effect,
   ElementRef,
   OnDestroy,
   ViewChild,
@@ -14,14 +15,29 @@ import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatInputModule } from '@angular/material/input';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
+import { AnalysisStoreApi } from '../../../core/api/analysis-store.api';
+import { mapPanelStateToSequencerPanelV1 } from '../../../core/mappers/analysis-store/panel-analysis-store.mapper';
+import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
 import { SequencerPanelService } from '../../../core/service/sequencer-panel.service';
 import { SequencerRuntimeService } from '../../../core/service/sequencer-runtime.service';
 import { HotkeysService } from '../../../core/services/hotkeys.service';
+import { AnalysisStoreVisibility } from '../../../interfaces/analysis-store';
 import { EventBtn, LabelBtn, SequencerBtn, StatBtn } from '../../../interfaces/sequencer-btn.interface';
+import {
+  analysisStoreLoadPanelFromValidatedPayload,
+  analysisStoreSavePanel,
+  analysisStoreSetCurrentPanel,
+} from '../../../store/AnalysisStore/analysis-store.actions';
+import { selectAnalysisStorePanelState } from '../../../store/AnalysisStore/analysis-store.selectors';
+import { hasImportDataLoss } from '../../../utils/sequencer/sequencer-panel-import.util';
 import { CreateEventBtnDialogComponent } from './createBtn/event/create-event-btn-dialog.component';
 import { CreateLabelBtnDialogComponent } from './createBtn/label/create-label-btn-dialog.component';
 import { CreateStatBtnDialogComponent } from './createBtn/stat/create-stat-btn-dialog.component';
 import { SequencerCanvasComponent } from './canvas/sequencer-canvas.component';
+import { PanelDescriptionDialogComponent } from './modals/panel-description-dialog/panel-description-dialog.component';
+import { PanelPublishDialogComponent } from './modals/panel-publish-dialog/panel-publish-dialog.component';
 
 @Component({
   selector: 'app-sequencer-panel',
@@ -35,17 +51,24 @@ import { SequencerCanvasComponent } from './canvas/sequencer-canvas.component';
     MatIconModule,
     MatDialogModule,
     MatInputModule,
+    MatSnackBarModule,
     SequencerCanvasComponent,
   ],
 })
 export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
   @ViewChild('panelRoot', { static: true }) panelRoot?: ElementRef<HTMLElement>;
+  @ViewChild('panelFileInput', { static: true }) panelFileInput?: ElementRef<HTMLInputElement>;
 
   private readonly panelService = inject(SequencerPanelService);
   private readonly runtimeService = inject(SequencerRuntimeService);
   private readonly hotkeysService = inject(HotkeysService);
+  private readonly analysisStoreApi = inject(AnalysisStoreApi);
+  private readonly confirmDialogService = inject(ConfirmDialogService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly store = inject(Store);
   private readonly dialog = inject(MatDialog);
   private resizeObserver?: ResizeObserver;
+  private readonly panelState = this.store.selectSignal(selectAnalysisStorePanelState);
 
   readonly panelName = this.panelService.panelName;
   readonly btnList = this.panelService.btnList;
@@ -59,6 +82,13 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
   readonly showEditIcons = computed(() => this.editMode() && !this.compactMode());
 
   readonly sortedBtnList = computed(() => [...this.btnList()]);
+
+  constructor() {
+    effect(() => {
+      const panel = this.panelService.getPanel();
+      this.store.dispatch(analysisStoreSetCurrentPanel({ panel }));
+    });
+  }
 
   ngAfterViewInit() {
     this.panelService.ensureAllLayouts();
@@ -159,4 +189,125 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
     this.renameDraft.set(target.value);
   }
 
+  triggerImportPanel() {
+    this.panelFileInput?.nativeElement.click();
+  }
+
+  async onImportPanelFileSelected(event: Event) {
+    const target = event.target as HTMLInputElement | null;
+    const file = target?.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    target.value = '';
+    try {
+      const rawContent = await file.text();
+      const parsedPayload = JSON.parse(rawContent) as Record<string, unknown>;
+      this.analysisStoreApi.validatePanelImport(parsedPayload).subscribe({
+        next: async response => {
+          if (!response.valid || !response.normalizedPayload) {
+            this.snackBar.open('Import invalide: vérifiez le fichier JSON.', 'Fermer', { duration: 3500 });
+            return;
+          }
+
+          if (hasImportDataLoss(this.panelService.getPanel(), response.normalizedPayload)) {
+            const shouldContinue = await this.confirmDialogService.confirm({
+              title: 'Écraser le panel courant ?',
+              message: 'Des boutons seront perdus. Voulez-vous continuer ?',
+              confirmLabel: 'Écraser',
+              cancelLabel: 'Annuler',
+            });
+            if (!shouldContinue) {
+              return;
+            }
+          }
+
+          this.store.dispatch(analysisStoreLoadPanelFromValidatedPayload({ payload: response.normalizedPayload }));
+          this.snackBar.open('Panel importé avec succès.', 'Fermer', { duration: 2500 });
+        },
+        error: () => {
+          this.snackBar.open('Échec de validation du panel importé.', 'Fermer', { duration: 3500 });
+        },
+      });
+    } catch {
+      this.snackBar.open('Le fichier sélectionné n’est pas un JSON valide.', 'Fermer', { duration: 3500 });
+      return;
+    }
+  }
+
+  exportPanel() {
+    const mapped = mapPanelStateToSequencerPanelV1(this.panelService.getPanel());
+    const blob = new Blob([JSON.stringify(mapped, null, 2)], { type: 'application/json' });
+    const fileName = `${mapped.panelName || 'panel'}.json`;
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = fileName;
+    link.click();
+    URL.revokeObjectURL(link.href);
+    this.snackBar.open('Export JSON généré.', 'Fermer', { duration: 2000 });
+  }
+
+  savePrivatePanel() {
+    this.store.dispatch(
+      analysisStoreSavePanel({
+        payload: {
+          visibility: 'private',
+          clubId: null,
+        },
+      }),
+    );
+  }
+
+  openEditDescriptionDialog() {
+    const dialogRef = this.dialog.open(PanelDescriptionDialogComponent, {
+      width: '460px',
+      data: { description: this.panelState().description },
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (!result) {
+        return;
+      }
+      this.store.dispatch(
+        analysisStoreSavePanel({
+          payload: {
+            description: result.description,
+          },
+        }),
+      );
+    });
+  }
+
+  openPublishDialog() {
+    const panelState = this.panelState();
+    const dialogRef = this.dialog.open(PanelPublishDialogComponent, {
+      width: '420px',
+      data: {
+        hasClubId: !!panelState.clubId,
+        currentVisibility: panelState.visibility,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (!result) {
+        return;
+      }
+
+      this.dispatchPublishSave(result.visibility);
+    });
+  }
+
+  private dispatchPublishSave(visibility: AnalysisStoreVisibility) {
+    const panelState = this.panelState();
+    const clubId = visibility === 'club' ? panelState.clubId : null;
+    this.store.dispatch(
+      analysisStoreSavePanel({
+        payload: {
+          visibility,
+          clubId,
+        },
+      }),
+    );
+  }
 }

--- a/src/app/core/service/sequencer-panel.service.ts
+++ b/src/app/core/service/sequencer-panel.service.ts
@@ -10,6 +10,7 @@ import {
   SequencerStatQuery,
   StatBtn,
 } from '../../interfaces/sequencer-btn.interface';
+import { SequencerPanel } from '../../interfaces/sequencer-panel.interface';
 import { SequencerBtnLayout } from '../../interfaces/sequencer-btn-layout.interface';
 import {
   defaultButtonHeightPx,
@@ -41,6 +42,18 @@ export class SequencerPanelService {
 
   setPanelName(name: string) {
     this.panelNameSignal.set(name.trim() || 'My Panel');
+  }
+
+  setPanel(panel: SequencerPanel) {
+    this.panelNameSignal.set(panel.panelName?.trim() || 'My Panel');
+    this.btnListSignal.set(panel.btnList.map(btn => ({ ...btn, layout: this.ensureLayout(btn) })));
+  }
+
+  getPanel(): SequencerPanel {
+    return {
+      panelName: this.panelNameSignal(),
+      btnList: this.btnListSignal(),
+    };
   }
 
   setEditMode(next: boolean) {

--- a/src/app/store/AnalysisStore/analysis-store.effects.ts
+++ b/src/app/store/AnalysisStore/analysis-store.effects.ts
@@ -1,13 +1,14 @@
 import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
-import { catchError, map, of, switchMap, withLatestFrom } from 'rxjs';
+import { catchError, map, of, switchMap, tap, withLatestFrom } from 'rxjs';
 import { AnalysisStoreApi } from '../../core/api/analysis-store.api';
 import {
   hasAnonymizedButtons,
   mapPanelStateToSequencerPanelV1,
   mapSequencerPanelV1ToPanelState,
 } from '../../core/mappers/analysis-store/panel-analysis-store.mapper';
+import { SequencerPanelService } from '../../core/service/sequencer-panel.service';
 import {
   mapAnalysisTimelineV1ToTimelineDocument,
   mapTimelineStateToAnalysisTimelineV1,
@@ -33,6 +34,7 @@ export class AnalysisStoreEffects {
   private readonly actions$ = inject(Actions);
   private readonly store = inject(Store);
   private readonly analysisStoreApi = inject(AnalysisStoreApi);
+  private readonly sequencerPanelService = inject(SequencerPanelService);
 
   readonly savePanel$ = createEffect(() =>
     this.actions$.pipe(
@@ -95,6 +97,15 @@ export class AnalysisStoreEffects {
         }),
       ),
     ),
+  );
+
+  readonly syncHydratedPanelToSequencerService$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreHydratePanelFromValidatedPayload),
+        tap(({ panel }) => this.sequencerPanelService.setPanel(panel)),
+      ),
+    { dispatch: false },
   );
 
   readonly loadTimelineFromValidatedPayload$ = createEffect(() =>

--- a/src/app/utils/sequencer/sequencer-panel-import.util.ts
+++ b/src/app/utils/sequencer/sequencer-panel-import.util.ts
@@ -1,0 +1,11 @@
+import { SequencerPanelV1 } from '../../interfaces/analysis-store';
+import { SequencerPanel } from '../../interfaces/sequencer-panel.interface';
+
+export function hasImportDataLoss(currentPanel: SequencerPanel, nextPanel: SequencerPanelV1): boolean {
+  if (!currentPanel.btnList.length) {
+    return false;
+  }
+
+  const nextIds = new Set(nextPanel.btnList.map(btn => btn.id));
+  return currentPanel.btnList.some(btn => !nextIds.has(btn.id));
+}


### PR DESCRIPTION
### Motivation
- Enable sequencer users to import/export panels, save private copies, publish (public/club) and edit panel description from the Sequencer UI while routing all writes through the existing analysis-store NgRx flow.

### Description
- Reused the Sequencer topbar `mat-menu` and toolbar to add menu entries and toolbar button with `mat-icon` for `Description`, `Exporter`, `Importer`, `Sauvegarder` and `Publier`, and added a hidden file input for local JSON import (`src/app/components/analyse/sequencer/sequencer-panel.component.html`/`.ts`).
- Implemented JSON import flow that reads a local file, calls `AnalysisStoreApi.validatePanelImport`, uses `normalizedPayload` when valid, prompts via `ConfirmDialogService` only on potential data loss using a new helper `hasImportDataLoss`, and dispatches `analysisStoreLoadPanelFromValidatedPayload` on success (`src/app/utils/sequencer/sequencer-panel-import.util.ts`, `src/app/components/.../sequencer-panel.component.ts`).
- Implemented export flow that maps current panel state to `SequencerPanelV1` and triggers a JSON download, plus Snackbar feedback (`mapPanelStateToSequencerPanelV1`, `exportPanel`).
- Implemented Save (private) and Publish flows by dispatching `analysisStoreSavePanel` with appropriate `visibility`/`clubId`, and added modal dialogs for description editing and publish visibility (`src/app/components/analyse/sequencer/modals/*`).
- Kept store-centric architecture: added `setPanel` / `getPanel` helpers to `SequencerPanelService`, dispatch `analysisStoreSetCurrentPanel` from the panel service state, and added an effect to sync hydrated panel meta back into `SequencerPanelService` on `analysisStoreHydratePanelFromValidatedPayload` (`src/app/core/service/sequencer-panel.service.ts`, `src/app/store/AnalysisStore/analysis-store.effects.ts`).

### Testing
- Ran `npm run lint` and all files passed linting successfully. 
- Ran `npm run build` and the build completed successfully (server prerender logs were present during generation but the build finished without blocking errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb87ab1b4832697404a4a0036cb4e)