### PR TITLE
feat(sequencer): ajouter « Trouver un panel » (modal) pour lister / utiliser / copier les panels

### DIFF
--- a/src/app/components/analyse/sequencer/modals/panel-finder-dialog/panel-buttons-preview-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/modals/panel-finder-dialog/panel-buttons-preview-dialog.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+
+export interface PanelButtonsPreviewDialogData {
+  title: string;
+  names: string[];
+}
+
+@Component({
+  selector: 'app-panel-buttons-preview-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  template: `
+    <h2 mat-dialog-title class="bg-layer-3 text-default m-0 text-center">{{ data.title }}</h2>
+    <mat-dialog-content class="bg-layer-3 text-default pt-3">
+      @if (data.names.length === 0) {
+        <p class="text-muted m-0 text-xs">Aucune donnée disponible.</p>
+      } @else {
+        <ul class="m-0 pl-4 text-sm">
+          @for (name of data.names; track name) {
+            <li>{{ name }}</li>
+          }
+        </ul>
+      }
+    </mat-dialog-content>
+    <mat-dialog-actions align="end" class="bg-layer-3 pb-3 pr-3">
+      <button mat-button type="button" (click)="close()">Fermer</button>
+    </mat-dialog-actions>
+  `,
+})
+export class PanelButtonsPreviewDialogComponent {
+  readonly data = inject<PanelButtonsPreviewDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef = inject(MatDialogRef<PanelButtonsPreviewDialogComponent>);
+
+  close() {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/components/analyse/sequencer/modals/panel-finder-dialog/panel-finder-dialog.component.html
+++ b/src/app/components/analyse/sequencer/modals/panel-finder-dialog/panel-finder-dialog.component.html
@@ -1,0 +1,82 @@
+<h2 mat-dialog-title class="bg-layer-3 text-default m-0 text-center">Trouver un panel</h2>
+
+<mat-dialog-content class="bg-layer-3 text-default flex max-h-[70vh] flex-col gap-3 pt-3">
+  <div class="flex flex-wrap items-center gap-2">
+    <mat-button-toggle-group
+      [ngModel]="visibilityFilter()"
+      (ngModelChange)="visibilityFilter.set($event)"
+      aria-label="Filtrer par visibilité"
+    >
+      <mat-button-toggle value="all">Tous</mat-button-toggle>
+      <mat-button-toggle value="public">Public</mat-button-toggle>
+      <mat-button-toggle value="private">Privé</mat-button-toggle>
+      <mat-button-toggle value="club">Club</mat-button-toggle>
+    </mat-button-toggle-group>
+
+    <mat-slide-toggle [ngModel]="onlyMine()" (ngModelChange)="onlyMine.set($event)">
+      Voir uniquement les miens
+    </mat-slide-toggle>
+  </div>
+
+  <input
+    class="bg-layer-2 border-subtle text-default w-full rounded border px-2 py-1 text-sm"
+    type="text"
+    placeholder="Rechercher un panel"
+    [ngModel]="searchTerm()"
+    (ngModelChange)="searchTerm.set($event)"
+  />
+
+  <div class="border-subtle bg-layer-2 overflow-auto rounded border">
+    <table mat-table [dataSource]="filteredPanels()" class="w-full">
+      <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef>Nom du panel</th>
+        <td mat-cell *matCellDef="let panel">{{ panel.title }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="visibility">
+        <th mat-header-cell *matHeaderCellDef>Visibilité</th>
+        <td mat-cell *matCellDef="let panel">{{ visibilityLabel(panel.visibility) }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="events">
+        <th mat-header-cell *matHeaderCellDef>Events</th>
+        <td mat-cell *matCellDef="let panel">
+          <button mat-icon-button type="button" (click)="showEvents(panel)" aria-label="Voir les events">
+            <mat-icon aria-hidden="true">event</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="labels">
+        <th mat-header-cell *matHeaderCellDef>Labels</th>
+        <td mat-cell *matCellDef="let panel">
+          <button mat-icon-button type="button" (click)="showLabels(panel)" aria-label="Voir les labels">
+            <mat-icon aria-hidden="true">label</mat-icon>
+          </button>
+        </td>
+      </ng-container>
+
+      <ng-container matColumnDef="action">
+        <th mat-header-cell *matHeaderCellDef>Action</th>
+        <td mat-cell *matCellDef="let panel">
+          @if (isOwner(panel)) {
+            <button mat-flat-button color="primary" type="button" (click)="usePanel(panel)">Utiliser</button>
+          } @else {
+            <button mat-stroked-button type="button" (click)="copyPanel(panel)">Copier</button>
+          }
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    @if (filteredPanels().length === 0) {
+      <div class="text-muted p-3 text-xs">Aucun panel ne correspond aux filtres.</div>
+    }
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="bg-layer-3 pb-3 pr-3">
+  <button mat-button type="button" (click)="close()">Fermer</button>
+</mat-dialog-actions>

--- a/src/app/components/analyse/sequencer/modals/panel-finder-dialog/panel-finder-dialog.component.ts
+++ b/src/app/components/analyse/sequencer/modals/panel-finder-dialog/panel-finder-dialog.component.ts
@@ -1,0 +1,128 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MAT_DIALOG_DATA, MatDialog, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTableModule } from '@angular/material/table';
+import { AnalysisStoreVisibility, PanelResourceResponse, SequencerPanelV1 } from '../../../../../interfaces/analysis-store';
+import { SequencerPanelBtnV1 } from '../../../../../interfaces/analysis-store/analysis-store-panel.interface';
+import { PanelButtonsPreviewDialogComponent } from './panel-buttons-preview-dialog.component';
+
+export interface PanelFinderDialogData {
+  panels: PanelResourceResponse[];
+  currentUserId: string | null;
+}
+
+export interface PanelFinderDialogResult {
+  action: 'use' | 'copy';
+  panel: PanelResourceResponse;
+}
+
+@Component({
+  selector: 'app-panel-finder-dialog',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTableModule,
+    MatButtonToggleModule,
+    MatSlideToggleModule,
+  ],
+  templateUrl: './panel-finder-dialog.component.html',
+})
+export class PanelFinderDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<PanelFinderDialogComponent, PanelFinderDialogResult | null>);
+  private readonly dialog = inject(MatDialog);
+  readonly data = inject<PanelFinderDialogData>(MAT_DIALOG_DATA);
+
+  readonly searchTerm = signal('');
+  readonly visibilityFilter = signal<'all' | AnalysisStoreVisibility>('all');
+  readonly onlyMine = signal(false);
+
+  readonly displayedColumns = ['title', 'visibility', 'events', 'labels', 'action'];
+
+  readonly filteredPanels = computed(() => {
+    const searchTerm = this.searchTerm().trim().toLowerCase();
+    const visibilityFilter = this.visibilityFilter();
+    const onlyMine = this.onlyMine();
+
+    return this.data.panels
+      .filter(panel => {
+        if (visibilityFilter !== 'all' && panel.visibility !== visibilityFilter) {
+          return false;
+        }
+        if (onlyMine && !this.isOwner(panel)) {
+          return false;
+        }
+        if (!searchTerm) {
+          return true;
+        }
+        return panel.title.toLowerCase().includes(searchTerm);
+      })
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  });
+
+  visibilityLabel(visibility: AnalysisStoreVisibility) {
+    if (visibility === 'public') {
+      return 'Public';
+    }
+    if (visibility === 'club') {
+      return 'Club';
+    }
+    return 'Privé';
+  }
+
+  isOwner(panel: PanelResourceResponse) {
+    return !!this.data.currentUserId && panel.ownerUserId === this.data.currentUserId;
+  }
+
+  showEvents(panel: PanelResourceResponse) {
+    const names = this.extractNames(panel, 'event');
+    this.dialog.open(PanelButtonsPreviewDialogComponent, {
+      width: '420px',
+      data: {
+        title: 'Events du panel',
+        names,
+      },
+    });
+  }
+
+  showLabels(panel: PanelResourceResponse) {
+    const names = this.extractNames(panel, 'label');
+    this.dialog.open(PanelButtonsPreviewDialogComponent, {
+      width: '420px',
+      data: {
+        title: 'Labels du panel',
+        names,
+      },
+    });
+  }
+
+  usePanel(panel: PanelResourceResponse) {
+    this.dialogRef.close({ action: 'use', panel });
+  }
+
+  copyPanel(panel: PanelResourceResponse) {
+    this.dialogRef.close({ action: 'copy', panel });
+  }
+
+  close() {
+    this.dialogRef.close(null);
+  }
+
+  private extractNames(panel: PanelResourceResponse, type: SequencerPanelBtnV1['type']) {
+    const payload = panel.contentJson as Partial<SequencerPanelV1>;
+    const btnList = Array.isArray(payload.btnList) ? payload.btnList : [];
+    return btnList
+      .filter((button): button is SequencerPanelBtnV1 => !!button && typeof button === 'object' && 'type' in button)
+      .filter(button => button.type === type)
+      .map(button => button.name)
+      .filter((name): name is string => typeof name === 'string' && name.trim().length > 0);
+  }
+}

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.html
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.html
@@ -24,6 +24,10 @@
         <mat-icon aria-hidden="true">save</mat-icon>
         <span>Sauvegarder</span>
       </button>
+      <button mat-menu-item type="button" (click)="openPanelFinderDialog()">
+        <mat-icon aria-hidden="true">search</mat-icon>
+        <span>Trouver un panel</span>
+      </button>
       <button mat-menu-item type="button" (click)="openPublishDialog()">
         <mat-icon aria-hidden="true">publish</mat-icon>
         <span>Publier</span>
@@ -54,6 +58,10 @@
         <button mat-menu-item type="button" (click)="savePrivatePanel()">
           <mat-icon aria-hidden="true">save</mat-icon>
           <span>Sauvegarder</span>
+        </button>
+        <button mat-menu-item type="button" (click)="openPanelFinderDialog()">
+          <mat-icon aria-hidden="true">search</mat-icon>
+          <span>Trouver un panel</span>
         </button>
         <button mat-menu-item type="button" (click)="openPublishDialog()">
           <mat-icon aria-hidden="true">publish</mat-icon>
@@ -102,6 +110,10 @@
 
       <button type="button" class="icon p-2" (click)="savePrivatePanel()" aria-label="Sauvegarder en privé" title="Sauvegarder">
         <mat-icon aria-hidden="true">save</mat-icon>
+      </button>
+
+      <button type="button" class="icon p-2" (click)="openPanelFinderDialog()" aria-label="Trouver un panel" title="Trouver un panel">
+        <mat-icon aria-hidden="true">search</mat-icon>
       </button>
     </div>
   }

--- a/src/app/components/analyse/sequencer/sequencer-panel.component.ts
+++ b/src/app/components/analyse/sequencer/sequencer-panel.component.ts
@@ -17,7 +17,9 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
+import { firstValueFrom } from 'rxjs';
 import { AnalysisStoreApi } from '../../../core/api/analysis-store.api';
+import { AuthSessionService } from '../../../core/auth/auth-session.service';
 import { mapPanelStateToSequencerPanelV1 } from '../../../core/mappers/analysis-store/panel-analysis-store.mapper';
 import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
 import { SequencerPanelService } from '../../../core/service/sequencer-panel.service';
@@ -36,6 +38,7 @@ import { CreateEventBtnDialogComponent } from './createBtn/event/create-event-bt
 import { CreateLabelBtnDialogComponent } from './createBtn/label/create-label-btn-dialog.component';
 import { CreateStatBtnDialogComponent } from './createBtn/stat/create-stat-btn-dialog.component';
 import { SequencerCanvasComponent } from './canvas/sequencer-canvas.component';
+import { PanelFinderDialogComponent, PanelFinderDialogResult } from './modals/panel-finder-dialog/panel-finder-dialog.component';
 import { PanelDescriptionDialogComponent } from './modals/panel-description-dialog/panel-description-dialog.component';
 import { PanelPublishDialogComponent } from './modals/panel-publish-dialog/panel-publish-dialog.component';
 
@@ -62,6 +65,7 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
   private readonly panelService = inject(SequencerPanelService);
   private readonly runtimeService = inject(SequencerRuntimeService);
   private readonly hotkeysService = inject(HotkeysService);
+  private readonly authSession = inject(AuthSessionService);
   private readonly analysisStoreApi = inject(AnalysisStoreApi);
   private readonly confirmDialogService = inject(ConfirmDialogService);
   private readonly snackBar = inject(MatSnackBar);
@@ -259,6 +263,35 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
     );
   }
 
+  async openPanelFinderDialog() {
+    try {
+      const panels = await firstValueFrom(this.analysisStoreApi.listPanels());
+      const dialogRef = this.dialog.open(PanelFinderDialogComponent, {
+        width: '980px',
+        maxWidth: '96vw',
+        data: {
+          panels,
+          currentUserId: this.authSession.user()?.id ?? null,
+        },
+      });
+
+      dialogRef.afterClosed().subscribe(async (result: PanelFinderDialogResult | null) => {
+        if (!result) {
+          return;
+        }
+
+        if (result.action === 'use') {
+          await this.loadPanelResource(result.panel.id, result.panel);
+          return;
+        }
+
+        await this.copyAndLoadPanel(result.panel.id);
+      });
+    } catch {
+      this.snackBar.open('Impossible de charger la liste des panels.', 'Fermer', { duration: 3500 });
+    }
+  }
+
   openEditDescriptionDialog() {
     const dialogRef = this.dialog.open(PanelDescriptionDialogComponent, {
       width: '460px',
@@ -309,5 +342,48 @@ export class SequencerPanelComponent implements AfterViewInit, OnDestroy {
         },
       }),
     );
+  }
+
+  private async loadPanelResource(panelId: string, contextResource: { id: string; title: string; description: string | null; visibility: AnalysisStoreVisibility; clubId: string | null; hasAnonymizedContent: boolean; }) {
+    try {
+      const payload = await firstValueFrom(this.analysisStoreApi.exportPanel(panelId));
+      if (hasImportDataLoss(this.panelService.getPanel(), payload)) {
+        const shouldContinue = await this.confirmDialogService.confirm({
+          title: 'Écraser le panel courant ?',
+          message: 'Le panel courant sera remplacé. Voulez-vous continuer ?',
+          confirmLabel: 'Écraser',
+          cancelLabel: 'Annuler',
+        });
+        if (!shouldContinue) {
+          return;
+        }
+      }
+
+      this.store.dispatch(
+        analysisStoreLoadPanelFromValidatedPayload({
+          payload,
+          context: {
+            resourceId: contextResource.id,
+            title: contextResource.title,
+            description: contextResource.description,
+            visibility: contextResource.visibility,
+            clubId: contextResource.clubId,
+            hasAnonymizedContent: contextResource.hasAnonymizedContent,
+          },
+        }),
+      );
+      this.snackBar.open('Panel chargé.', 'Fermer', { duration: 2200 });
+    } catch {
+      this.snackBar.open('Impossible de charger ce panel.', 'Fermer', { duration: 3500 });
+    }
+  }
+
+  private async copyAndLoadPanel(sourcePanelId: string) {
+    try {
+      const copied = await firstValueFrom(this.analysisStoreApi.copyPanel(sourcePanelId));
+      await this.loadPanelResource(copied.id, copied);
+    } catch {
+      this.snackBar.open('Impossible de copier ce panel.', 'Fermer', { duration: 3500 });
+    }
   }
 }


### PR DESCRIPTION
### Motivation
- Ajouter un accès dans la toolbar du séquenceur pour retrouver des panels lisibles depuis `analysis-store` et permettre de les charger sans casser les patterns Material/Ngrx existants.
- Respecter la contrainte métier : toute modification de l’état passe par le store et confirmation d’écrasement uniquement si perte de données détectée.
- Offrir le vrai comportement backend pour les copies via la route `POST /api/panels/:id/copy` exposée par `AnalysisStoreApi`.

### Description
- Ajout d’un bouton `Trouver un panel` (icône `search`) dans la toolbar du composant `SequencerPanelComponent` et dans le menu compact de la toolbar.
- Création de la modal `PanelFinderDialogComponent` (Material) avec un tableau, filtres de visibilité (`public`/`private`/`club` + `Tous`), toggle `Voir uniquement les miens`, et recherche par nom, et d’une modale de prévisualisation simple `PanelButtonsPreviewDialogComponent` pour afficher `events` / `labels`.
- Actions ligne implémentées : `Voir events`, `Voir labels`, `Utiliser` (si owner détecté via `AuthSessionService`), `Copier` (si non-owner) ; `Utiliser` appelle `exportPanel` puis dispatch `analysisStoreLoadPanelFromValidatedPayload` et `Copier` appelle `copyPanel` puis charge la ressource retournée.
- Protection d’écrasement : règle de confirmation basée sur `hasImportDataLoss(...)` avant de remplacer le panel courant, et utilisation exclusive du store pour hydrater le `SequencerPanelService` (pipeline via `analysisStoreLoadPanelFromValidatedPayload` et les effets existants).

### Testing
- Lint : `npm run lint` exécuté et tous les fichiers passent le linting (succès).
- Build : `npm run build` exécuté et la compilation/production build complète avec succès (prerender/SSR logs observés mais non bloquants).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcbdf58bbc8326a0e6d97e61afc8b4)