### PR TITLE
feat(timeline): add analysis-store integration for save/import/export/load

### DIFF
--- a/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.html
+++ b/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.html
@@ -30,8 +30,8 @@
         </td>
       </ng-container>
 
-      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns" class="find-panels-header-row"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns" class="find-panels-data-row"></tr>
     </table>
 
     @if (filteredTimelines().length === 0) {

--- a/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.html
+++ b/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.html
@@ -13,7 +13,7 @@
     <table mat-table [dataSource]="filteredTimelines()" class="w-full">
       <ng-container matColumnDef="title">
         <th mat-header-cell *matHeaderCellDef>Nom</th>
-        <td mat-cell *matCellDef="let timeline">{{ timeline.title }}</td>
+        <td mat-cell *matCellDef="let timeline">{{ timeline.displayName }}</td>
       </ng-container>
 
       <ng-container matColumnDef="updatedAt">
@@ -24,7 +24,7 @@
       <ng-container matColumnDef="action">
         <th mat-header-cell *matHeaderCellDef>Action</th>
         <td mat-cell *matCellDef="let timeline">
-          <button mat-flat-button color="primary" type="button" (click)="select(timeline)">
+          <button mat-flat-button color="primary" type="button" (click)="select(timeline.resource)">
             Charger
           </button>
         </td>

--- a/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.html
+++ b/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.html
@@ -1,0 +1,45 @@
+<h2 mat-dialog-title class="bg-layer-3 text-default m-0 text-center">Charger une timeline distante</h2>
+
+<mat-dialog-content class="bg-layer-3 text-default flex max-h-[70vh] flex-col gap-4 pt-4">
+  <input
+    class="bg-layer-2 border-subtle text-default w-full rounded border px-3 py-2 text-sm"
+    type="text"
+    placeholder="Rechercher une timeline"
+    [ngModel]="searchTerm()"
+    (ngModelChange)="searchTerm.set($event)"
+  />
+
+  <div class="border-subtle bg-layer-2 overflow-auto rounded border">
+    <table mat-table [dataSource]="filteredTimelines()" class="w-full">
+      <ng-container matColumnDef="title">
+        <th mat-header-cell *matHeaderCellDef>Nom</th>
+        <td mat-cell *matCellDef="let timeline">{{ timeline.title }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="updatedAt">
+        <th mat-header-cell *matHeaderCellDef>Dernière mise à jour</th>
+        <td mat-cell *matCellDef="let timeline">{{ timeline.updatedAt | date: 'short' }}</td>
+      </ng-container>
+
+      <ng-container matColumnDef="action">
+        <th mat-header-cell *matHeaderCellDef>Action</th>
+        <td mat-cell *matCellDef="let timeline">
+          <button mat-flat-button color="primary" type="button" (click)="select(timeline)">
+            Charger
+          </button>
+        </td>
+      </ng-container>
+
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+
+    @if (filteredTimelines().length === 0) {
+      <div class="text-muted p-3 text-xs">Aucune timeline ne correspond aux filtres.</div>
+    }
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end" class="bg-layer-3 pb-3 pr-3">
+  <button mat-button type="button" (click)="close()">Fermer</button>
+</mat-dialog-actions>

--- a/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.ts
+++ b/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.ts
@@ -1,0 +1,40 @@
+import { CommonModule } from '@angular/common';
+import { Component, computed, inject, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { TimelineResourceResponse } from '../../../../interfaces/analysis-store';
+
+export interface TimelineFinderDialogData {
+  timelines: TimelineResourceResponse[];
+}
+
+@Component({
+  selector: 'app-timeline-finder-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule, MatDialogModule, MatButtonModule, MatIconModule, MatTableModule],
+  templateUrl: './timeline-finder-dialog.component.html',
+})
+export class TimelineFinderDialogComponent {
+  private readonly dialogRef = inject(MatDialogRef<TimelineFinderDialogComponent, TimelineResourceResponse | null>);
+  readonly data = inject<TimelineFinderDialogData>(MAT_DIALOG_DATA);
+  readonly searchTerm = signal('');
+  readonly displayedColumns = ['title', 'updatedAt', 'action'];
+
+  readonly filteredTimelines = computed(() => {
+    const search = this.searchTerm().trim().toLowerCase();
+    return this.data.timelines
+      .filter(resource => !search || resource.title.toLowerCase().includes(search))
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  });
+
+  select(resource: TimelineResourceResponse) {
+    this.dialogRef.close(resource);
+  }
+
+  close() {
+    this.dialogRef.close(null);
+  }
+}

--- a/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.ts
+++ b/src/app/components/analyse/timeline/modals/timeline-finder-dialog.component.ts
@@ -11,6 +11,12 @@ export interface TimelineFinderDialogData {
   timelines: TimelineResourceResponse[];
 }
 
+interface TimelineFinderRow {
+  resource: TimelineResourceResponse;
+  displayName: string;
+  updatedAt: string;
+}
+
 @Component({
   selector: 'app-timeline-finder-dialog',
   standalone: true,
@@ -23,10 +29,18 @@ export class TimelineFinderDialogComponent {
   readonly searchTerm = signal('');
   readonly displayedColumns = ['title', 'updatedAt', 'action'];
 
+  readonly rows = computed<TimelineFinderRow[]>(() =>
+    this.data.timelines.map(resource => ({
+      resource,
+      displayName: this.resolveDisplayName(resource),
+      updatedAt: resource.updatedAt,
+    })),
+  );
+
   readonly filteredTimelines = computed(() => {
     const search = this.searchTerm().trim().toLowerCase();
-    return this.data.timelines
-      .filter(resource => !search || resource.title.toLowerCase().includes(search))
+    return this.rows()
+      .filter(row => !search || row.displayName.toLowerCase().includes(search))
       .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
   });
 
@@ -36,5 +50,25 @@ export class TimelineFinderDialogComponent {
 
   close() {
     this.dialogRef.close(null);
+  }
+
+  private resolveDisplayName(resource: TimelineResourceResponse): string {
+    const timelineName = this.readTimelineName(resource.contentJson);
+    if (timelineName) {
+      return timelineName;
+    }
+
+    const fallbackTitle = resource.title?.trim();
+    return fallbackTitle || 'Timeline';
+  }
+
+  private readTimelineName(contentJson: Record<string, unknown>): string | null {
+    const rawTimelineName = contentJson?.['timelineName'];
+    if (typeof rawTimelineName !== 'string') {
+      return null;
+    }
+
+    const trimmed = rawTimelineName.trim();
+    return trimmed.length > 0 ? trimmed : null;
   }
 }

--- a/src/app/components/analyse/timeline/timeline.component.html
+++ b/src/app/components/analyse/timeline/timeline.component.html
@@ -60,6 +60,47 @@
     ></app-zoom-controls>
 
     <button
+      class="icon flex items-center p-2"
+      type="button"
+      [disabled]="isTimelineSaving()"
+      (click)="saveTimeline()"
+      aria-label="Sauvegarder la timeline"
+      title="Sauvegarder la timeline"
+    >
+      <mat-icon aria-hidden="true">save</mat-icon>
+    </button>
+
+    <button
+      class="icon flex items-center p-2"
+      type="button"
+      (click)="openTimelineFinderDialog()"
+      aria-label="Charger une timeline distante"
+      title="Charger une timeline distante"
+    >
+      <mat-icon aria-hidden="true">cloud_download</mat-icon>
+    </button>
+
+    <button
+      class="icon flex items-center p-2"
+      type="button"
+      [matMenuTriggerFor]="timelineMenu"
+      aria-label="Menu timeline"
+      title="Importer / Exporter"
+    >
+      <mat-icon aria-hidden="true">more_vert</mat-icon>
+    </button>
+    <mat-menu #timelineMenu="matMenu">
+      <button mat-menu-item type="button" (click)="triggerImportTimeline()">
+        <mat-icon aria-hidden="true">upload_file</mat-icon>
+        <span>Importer</span>
+      </button>
+      <button mat-menu-item type="button" (click)="exportTimeline()">
+        <mat-icon aria-hidden="true">download</mat-icon>
+        <span>Exporter</span>
+      </button>
+    </mat-menu>
+
+    <button
       class="btn-secondary ml-auto flex items-center justify-center"
       type="button"
       aria-label="Supprimer la sélection"
@@ -174,3 +215,10 @@
     </div>
   }
 </div>
+<input
+  #timelineFileInput
+  type="file"
+  accept="application/json,.json"
+  class="hidden"
+  (change)="onImportTimelineFileSelected($event)"
+/>

--- a/src/app/components/analyse/timeline/timeline.component.ts
+++ b/src/app/components/analyse/timeline/timeline.component.ts
@@ -295,7 +295,6 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
 
   saveTimeline() {
     this.store.dispatch(analysisStoreSaveTimeline({}));
-    this.snackBar.open('Sauvegarde de la timeline en cours…', 'Fermer', { duration: 1800 });
   }
 
   triggerImportTimeline() {
@@ -328,7 +327,6 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
       }
 
       this.store.dispatch(analysisStoreImportTimeline({ payload: parsedPayload }));
-      this.snackBar.open('Validation de la timeline importée en cours…', 'Fermer', { duration: 2200 });
     } catch {
       this.snackBar.open('Le fichier sélectionné n’est pas un JSON valide.', 'Fermer', { duration: 3500 });
     }
@@ -336,7 +334,6 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
 
   exportTimeline() {
     this.store.dispatch(analysisStoreExportTimeline());
-    this.snackBar.open('Export JSON généré.', 'Fermer', { duration: 2000 });
   }
 
   async openTimelineFinderDialog() {
@@ -358,6 +355,7 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
     const dialogRef = this.dialog.open(TimelineFinderDialogComponent, {
       width: '860px',
       maxWidth: '96vw',
+      panelClass: 'analysis-panel-finder-dialog',
       data: {
         timelines: resources,
       },
@@ -381,7 +379,6 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
       }
 
       this.store.dispatch(analysisStoreLoadRemoteTimeline({ resource }));
-      this.snackBar.open('Chargement de la timeline distante…', 'Fermer', { duration: 1800 });
     });
   }
 

--- a/src/app/components/analyse/timeline/timeline.component.ts
+++ b/src/app/components/analyse/timeline/timeline.component.ts
@@ -13,6 +13,10 @@ import {
 } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Store } from '@ngrx/store';
+import { filter, firstValueFrom, skip, take } from 'rxjs';
 import {
   TIMELINE_AUTO_FOLLOW_COMFORT_ZONE,
   TIMELINE_AUTO_FOLLOW_TARGET_RATIO,
@@ -22,28 +26,50 @@ import {
 import { TimelineFacadeService } from '../../../core/services/timeline-facade.service';
 import { TimebaseService } from '../../../core/services/timebase.service';
 import { TimelineOccurrence } from '../../../interfaces/timeline/timeline.interface';
+import { TimelineResourceResponse } from '../../../interfaces/analysis-store';
 import { TimelineLabelsDialogComponent } from './timeline-labels-dialog.component';
 import { getReadableTextColor } from '../../../utils/color/color-contrast.utils';
 import { ConfirmDialogService } from '../../../core/services/confirm-dialog.service';
 import { TimelineZoomService } from '../../../core/services/timeline-zoom.service';
 import { ZoomControlsComponent } from '../../shared/zoom-controls/zoom-controls.component';
+import {
+  analysisStoreExportTimeline,
+  analysisStoreImportTimeline,
+  analysisStoreLoadRemoteTimeline,
+  analysisStoreLoadTimelineList,
+  analysisStoreSaveTimeline,
+} from '../../../store/AnalysisStore/analysis-store.actions';
+import {
+  selectAnalysisStoreTimelineOps,
+  selectAnalysisStoreTimelineResources,
+} from '../../../store/AnalysisStore/analysis-store.selectors';
+import { selectTimelineState } from '../../../store/Timeline/timeline.selectors';
+import { hasTimelineImportDataLossFromRawPayload } from '../../../utils/timeline/timeline-import.util';
+import { TimelineFinderDialogComponent } from './modals/timeline-finder-dialog.component';
 
 @Component({
   selector: 'app-timeline',
   standalone: true,
-  imports: [CommonModule, MatIconModule, ZoomControlsComponent],
+  imports: [CommonModule, MatIconModule, MatMenuModule, ZoomControlsComponent],
   templateUrl: './timeline.component.html',
   styleUrl: './timeline.component.scss',
 })
 export class TimelineComponent implements OnDestroy, AfterViewInit {
   @ViewChild('timeScrollEl', { static: false }) timeScrollElRef?: ElementRef<HTMLDivElement>;
   @ViewChild('timelineRoot', { static: false }) timelineRootRef?: ElementRef<HTMLDivElement>;
+  @ViewChild('timelineFileInput', { static: true }) timelineFileInput?: ElementRef<HTMLInputElement>;
 
   readonly facade = inject(TimelineFacadeService);
   readonly timebase = inject(TimebaseService);
   private readonly dialog = inject(MatDialog);
   private readonly confirmDialogService = inject(ConfirmDialogService);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly store = inject(Store);
   readonly timelineZoom = inject(TimelineZoomService);
+
+  private readonly timelineOps = this.store.selectSignal(selectAnalysisStoreTimelineOps);
+  private readonly timelineResources = this.store.selectSignal(selectAnalysisStoreTimelineResources);
+  private readonly timelineState = this.store.selectSignal(selectTimelineState);
 
   readonly rowHeightPx = TIMELINE_ROW_HEIGHT_PX;
   readonly rulerHeightPx = 36;
@@ -133,6 +159,7 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
   readonly selectedCount = computed(() => this.facade.selectionIds().length);
   readonly selectionContainsOpen = computed(() => this.selectedOccurrences().some(occurrence => occurrence.isOpen));
   readonly canDeleteSelection = computed(() => this.selectedCount() > 0 && !this.selectionContainsOpen());
+  readonly isTimelineSaving = computed(() => this.timelineOps().isSaving);
 
   private readonly labelNameById = computed(() =>
     this.facade.labelDefs().reduce<Record<string, string>>((accumulator, definition) => {
@@ -264,6 +291,98 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
     if (!this.isProgrammaticScrollSignal() && this.timebase.isPlaying() && this.facade.autoFollow()) {
       this.facade.setAutoFollow(false);
     }
+  }
+
+  saveTimeline() {
+    this.store.dispatch(analysisStoreSaveTimeline({}));
+    this.snackBar.open('Sauvegarde de la timeline en cours…', 'Fermer', { duration: 1800 });
+  }
+
+  triggerImportTimeline() {
+    this.timelineFileInput?.nativeElement.click();
+  }
+
+  async onImportTimelineFileSelected(event: Event) {
+    const target = event.target as HTMLInputElement | null;
+    const file = target?.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    target.value = '';
+
+    try {
+      const rawContent = await file.text();
+      const parsedPayload = JSON.parse(rawContent) as Record<string, unknown>;
+
+      if (hasTimelineImportDataLossFromRawPayload(this.timelineState(), parsedPayload)) {
+        const shouldContinue = await this.confirmDialogService.confirm({
+          title: 'Écraser la timeline courante ?',
+          message: 'Des événements/occurrences seront perdus. Voulez-vous continuer ?',
+          confirmLabel: 'Écraser',
+          cancelLabel: 'Annuler',
+        });
+        if (!shouldContinue) {
+          return;
+        }
+      }
+
+      this.store.dispatch(analysisStoreImportTimeline({ payload: parsedPayload }));
+      this.snackBar.open('Validation de la timeline importée en cours…', 'Fermer', { duration: 2200 });
+    } catch {
+      this.snackBar.open('Le fichier sélectionné n’est pas un JSON valide.', 'Fermer', { duration: 3500 });
+    }
+  }
+
+  exportTimeline() {
+    this.store.dispatch(analysisStoreExportTimeline());
+    this.snackBar.open('Export JSON généré.', 'Fermer', { duration: 2000 });
+  }
+
+  async openTimelineFinderDialog() {
+    this.store.dispatch(analysisStoreLoadTimelineList());
+    await firstValueFrom(
+      this.store.select(selectAnalysisStoreTimelineOps).pipe(
+        skip(1),
+        filter(ops => !ops.isLoadingList),
+        take(1),
+      ),
+    );
+
+    const resources = this.timelineResources();
+    if (!resources.length) {
+      this.snackBar.open('Aucune timeline distante disponible.', 'Fermer', { duration: 2800 });
+      return;
+    }
+
+    const dialogRef = this.dialog.open(TimelineFinderDialogComponent, {
+      width: '860px',
+      maxWidth: '96vw',
+      data: {
+        timelines: resources,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe(async (resource: TimelineResourceResponse | null) => {
+      if (!resource) {
+        return;
+      }
+
+      if (this.shouldConfirmReplaceCurrentTimeline()) {
+        const shouldContinue = await this.confirmDialogService.confirm({
+          title: 'Remplacer la timeline courante ?',
+          message: 'La timeline locale sera remplacée par la timeline distante sélectionnée.',
+          confirmLabel: 'Remplacer',
+          cancelLabel: 'Annuler',
+        });
+        if (!shouldContinue) {
+          return;
+        }
+      }
+
+      this.store.dispatch(analysisStoreLoadRemoteTimeline({ resource }));
+      this.snackBar.open('Chargement de la timeline distante…', 'Fermer', { duration: 1800 });
+    });
   }
 
   async deleteSelection() {
@@ -525,5 +644,14 @@ export class TimelineComponent implements OnDestroy, AfterViewInit {
       this.isProgrammaticScrollSignal.set(false);
       this.programmaticScrollTimeoutId = undefined;
     }, 120);
+  }
+
+  private shouldConfirmReplaceCurrentTimeline() {
+    const timeline = this.timelineState();
+    return (
+      timeline.definitions.eventDefs.length > 0 ||
+      timeline.definitions.labelDefs.length > 0 ||
+      timeline.occurrences.length > 0
+    );
   }
 }

--- a/src/app/core/api/analysis-store.api.ts
+++ b/src/app/core/api/analysis-store.api.ts
@@ -45,10 +45,10 @@ export class AnalysisStoreApi {
 
   upsertTimeline(payload: UpsertTimelineResourceBody): Observable<TimelineResourceResponse> {
     if (payload.id) {
-      return this.updateTimeline(payload.id, payload);
+      return this.updateTimeline(payload.id, this.toUpdateTimelineBody(payload));
     }
 
-    return this.createTimeline(payload as CreateTimelineResourceBody);
+    return this.createTimeline(this.toCreateTimelineBody(payload));
   }
 
   createTimeline(payload: CreateTimelineResourceBody): Observable<TimelineResourceResponse> {
@@ -77,10 +77,10 @@ export class AnalysisStoreApi {
 
   upsertPanel(payload: UpsertPanelResourceBody): Observable<PanelResourceResponse> {
     if (payload.id) {
-      return this.updatePanel(payload.id, payload);
+      return this.updatePanel(payload.id, this.toUpdatePanelBody(payload));
     }
 
-    return this.createPanel(payload as CreatePanelResourceBody);
+    return this.createPanel(this.toCreatePanelBody(payload));
   }
 
   createPanel(payload: CreatePanelResourceBody): Observable<PanelResourceResponse> {
@@ -105,5 +105,45 @@ export class AnalysisStoreApi {
 
   private buildExportUrl(collectionUrl: string, id: string): string {
     return `${this.buildResourceUrl(collectionUrl, id)}/export`;
+  }
+
+  private toCreateTimelineBody(payload: UpsertTimelineResourceBody): CreateTimelineResourceBody {
+    return {
+      title: payload.title ?? 'Timeline',
+      description: payload.description,
+      contentJson: payload.contentJson,
+      hasAnonymizedContent: payload.hasAnonymizedContent,
+    };
+  }
+
+  private toUpdateTimelineBody(payload: UpsertTimelineResourceBody): UpdateTimelineResourceBody {
+    return {
+      title: payload.title,
+      description: payload.description,
+      contentJson: payload.contentJson,
+      hasAnonymizedContent: payload.hasAnonymizedContent,
+    };
+  }
+
+  private toCreatePanelBody(payload: UpsertPanelResourceBody): CreatePanelResourceBody {
+    return {
+      title: payload.title ?? 'My Panel',
+      description: payload.description,
+      contentJson: payload.contentJson,
+      visibility: payload.visibility,
+      clubId: payload.clubId,
+      hasAnonymizedContent: payload.hasAnonymizedContent,
+    };
+  }
+
+  private toUpdatePanelBody(payload: UpsertPanelResourceBody): UpdatePanelResourceBody {
+    return {
+      title: payload.title,
+      description: payload.description,
+      contentJson: payload.contentJson,
+      visibility: payload.visibility,
+      clubId: payload.clubId,
+      hasAnonymizedContent: payload.hasAnonymizedContent,
+    };
   }
 }

--- a/src/app/store/AnalysisStore/analysis-store.actions.ts
+++ b/src/app/store/AnalysisStore/analysis-store.actions.ts
@@ -2,6 +2,7 @@ import { createAction, props } from '@ngrx/store';
 import {
   AnalysisStoreVisibility,
   AnalysisTimelineV1,
+  AnalysisStoreImportValidationPayload,
   PanelResourceResponse,
   SequencerPanelV1,
   TimelineResourceResponse,
@@ -81,5 +82,42 @@ export const analysisStoreSaveTimelineSuccess = createAction(
 );
 export const analysisStoreSaveTimelineFailure = createAction(
   '[Analysis Store] Save Timeline Failure',
+  props<{ error: string }>(),
+);
+
+export const analysisStoreImportTimeline = createAction(
+  '[Analysis Store] Import Timeline',
+  props<{ payload: AnalysisStoreImportValidationPayload; context?: AnalysisStoreLoadResourceContext }>(),
+);
+export const analysisStoreImportTimelineSuccess = createAction('[Analysis Store] Import Timeline Success');
+export const analysisStoreImportTimelineFailure = createAction(
+  '[Analysis Store] Import Timeline Failure',
+  props<{ error: string }>(),
+);
+
+export const analysisStoreExportTimeline = createAction('[Analysis Store] Export Timeline');
+export const analysisStoreExportTimelineSuccess = createAction('[Analysis Store] Export Timeline Success');
+export const analysisStoreExportTimelineFailure = createAction(
+  '[Analysis Store] Export Timeline Failure',
+  props<{ error: string }>(),
+);
+
+export const analysisStoreLoadTimelineList = createAction('[Analysis Store] Load Timeline List');
+export const analysisStoreLoadTimelineListSuccess = createAction(
+  '[Analysis Store] Load Timeline List Success',
+  props<{ resources: TimelineResourceResponse[] }>(),
+);
+export const analysisStoreLoadTimelineListFailure = createAction(
+  '[Analysis Store] Load Timeline List Failure',
+  props<{ error: string }>(),
+);
+
+export const analysisStoreLoadRemoteTimeline = createAction(
+  '[Analysis Store] Load Remote Timeline',
+  props<{ resource: TimelineResourceResponse }>(),
+);
+export const analysisStoreLoadRemoteTimelineSuccess = createAction('[Analysis Store] Load Remote Timeline Success');
+export const analysisStoreLoadRemoteTimelineFailure = createAction(
+  '[Analysis Store] Load Remote Timeline Failure',
   props<{ error: string }>(),
 );

--- a/src/app/store/AnalysisStore/analysis-store.effects.ts
+++ b/src/app/store/AnalysisStore/analysis-store.effects.ts
@@ -1,5 +1,6 @@
 import { DOCUMENT } from '@angular/common';
 import { Injectable, inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
 import { catchError, map, of, switchMap, tap, withLatestFrom } from 'rxjs';
@@ -49,6 +50,7 @@ export class AnalysisStoreEffects {
   private readonly analysisStoreApi = inject(AnalysisStoreApi);
   private readonly sequencerPanelService = inject(SequencerPanelService);
   private readonly document = inject(DOCUMENT);
+  private readonly snackBar = inject(MatSnackBar);
 
   readonly savePanel$ = createEffect(() =>
     this.actions$.pipe(
@@ -225,5 +227,114 @@ export class AnalysisStoreEffects {
         ),
       ),
     ),
+  );
+
+  readonly notifyPanelSaveSuccess$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreSavePanelSuccess),
+        tap(() => this.snackBar.open('Panel sauvegardé avec succès.', 'Fermer', { duration: 2500 })),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyPanelSaveFailure$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreSavePanelFailure),
+        tap(({ error }) => this.snackBar.open(error || 'Échec de sauvegarde du panel.', 'Fermer', { duration: 3500 })),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineSaveSuccess$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreSaveTimelineSuccess),
+        tap(() => this.snackBar.open('Timeline sauvegardée avec succès.', 'Fermer', { duration: 2500 })),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineSaveFailure$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreSaveTimelineFailure),
+        tap(({ error }) =>
+          this.snackBar.open(error || 'Échec de sauvegarde de la timeline.', 'Fermer', { duration: 3500 }),
+        ),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineImportSuccess$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreImportTimelineSuccess),
+        tap(() => this.snackBar.open('Timeline importée avec succès.', 'Fermer', { duration: 2500 })),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineImportFailure$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreImportTimelineFailure),
+        tap(({ error }) =>
+          this.snackBar.open(error || 'Échec de validation de la timeline importée.', 'Fermer', { duration: 3500 }),
+        ),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineExportSuccess$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreExportTimelineSuccess),
+        tap(() => this.snackBar.open('Export timeline généré.', 'Fermer', { duration: 2200 })),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineExportFailure$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreExportTimelineFailure),
+        tap(({ error }) =>
+          this.snackBar.open(error || 'Échec de l’export timeline.', 'Fermer', { duration: 3500 }),
+        ),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineLoadSuccess$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreLoadRemoteTimelineSuccess),
+        tap(() => this.snackBar.open('Timeline distante chargée.', 'Fermer', { duration: 2500 })),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineLoadFailure$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreLoadRemoteTimelineFailure),
+        tap(({ error }) =>
+          this.snackBar.open(error || 'Impossible de charger la timeline distante.', 'Fermer', { duration: 3500 }),
+        ),
+      ),
+    { dispatch: false },
+  );
+
+  readonly notifyTimelineListFailure$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(analysisStoreLoadTimelineListFailure),
+        tap(({ error }) =>
+          this.snackBar.open(error || 'Impossible de charger la liste des timelines.', 'Fermer', { duration: 3500 }),
+        ),
+      ),
+    { dispatch: false },
   );
 }

--- a/src/app/store/AnalysisStore/analysis-store.effects.ts
+++ b/src/app/store/AnalysisStore/analysis-store.effects.ts
@@ -1,3 +1,4 @@
+import { DOCUMENT } from '@angular/common';
 import { Injectable, inject } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Store } from '@ngrx/store';
@@ -16,10 +17,22 @@ import {
 import { initTimeline } from '../Timeline/timeline.actions';
 import { selectTimelineState } from '../Timeline/timeline.selectors';
 import {
+  analysisStoreExportTimeline,
+  analysisStoreExportTimelineFailure,
+  analysisStoreExportTimelineSuccess,
   analysisStoreHydratePanelFromValidatedPayload,
   analysisStoreHydrateTimelineResourceMeta,
+  analysisStoreImportTimeline,
+  analysisStoreImportTimelineFailure,
+  analysisStoreImportTimelineSuccess,
   analysisStoreLoadPanelFromValidatedPayload,
+  analysisStoreLoadRemoteTimeline,
+  analysisStoreLoadRemoteTimelineFailure,
+  analysisStoreLoadRemoteTimelineSuccess,
   analysisStoreLoadTimelineFromValidatedPayload,
+  analysisStoreLoadTimelineList,
+  analysisStoreLoadTimelineListFailure,
+  analysisStoreLoadTimelineListSuccess,
   analysisStoreSavePanel,
   analysisStoreSavePanelFailure,
   analysisStoreSavePanelSuccess,
@@ -35,6 +48,7 @@ export class AnalysisStoreEffects {
   private readonly store = inject(Store);
   private readonly analysisStoreApi = inject(AnalysisStoreApi);
   private readonly sequencerPanelService = inject(SequencerPanelService);
+  private readonly document = inject(DOCUMENT);
 
   readonly savePanel$ = createEffect(() =>
     this.actions$.pipe(
@@ -127,6 +141,89 @@ export class AnalysisStoreEffects {
     this.actions$.pipe(
       ofType(analysisStoreLoadTimelineFromValidatedPayload),
       map(({ payload, context }) => analysisStoreHydrateTimelineResourceMeta({ timeline: payload, context })),
+    ),
+  );
+
+  readonly importTimeline$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreImportTimeline),
+      switchMap(({ payload, context }) =>
+        this.analysisStoreApi.validateTimelineImport(payload).pipe(
+          switchMap(response => {
+            if (!response.valid || !response.normalizedPayload) {
+              return of(analysisStoreImportTimelineFailure({ error: 'Import timeline invalide.' }));
+            }
+
+            return of(
+              analysisStoreLoadTimelineFromValidatedPayload({ payload: response.normalizedPayload, context }),
+              analysisStoreImportTimelineSuccess(),
+            );
+          }),
+          catchError(error =>
+            of(analysisStoreImportTimelineFailure({ error: error?.message ?? 'Timeline import validation failed' })),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  readonly exportTimeline$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreExportTimeline),
+      withLatestFrom(this.store.select(selectTimelineState)),
+      tap(([, timelineState]) => {
+        const mappedTimeline = mapTimelineStateToAnalysisTimelineV1(timelineState);
+        const fileName = `${mappedTimeline.timelineName || 'timeline'}.json`;
+        const blob = new Blob([JSON.stringify(mappedTimeline, null, 2)], { type: 'application/json' });
+        const link = this.document.createElement('a');
+        link.href = URL.createObjectURL(blob);
+        link.download = fileName;
+        link.click();
+        URL.revokeObjectURL(link.href);
+      }),
+      map(() => analysisStoreExportTimelineSuccess()),
+      catchError(error => of(analysisStoreExportTimelineFailure({ error: error?.message ?? 'Timeline export failed' }))),
+    ),
+  );
+
+  readonly loadTimelineList$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreLoadTimelineList),
+      switchMap(() =>
+        this.analysisStoreApi.listTimelines().pipe(
+          map(resources => analysisStoreLoadTimelineListSuccess({ resources })),
+          catchError(error =>
+            of(analysisStoreLoadTimelineListFailure({ error: error?.message ?? 'Timeline list loading failed' })),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  readonly loadRemoteTimeline$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(analysisStoreLoadRemoteTimeline),
+      switchMap(({ resource }) =>
+        this.analysisStoreApi.exportTimeline(resource.id).pipe(
+          switchMap(payload =>
+            of(
+              analysisStoreLoadTimelineFromValidatedPayload({
+                payload,
+                context: {
+                  resourceId: resource.id,
+                  title: resource.title,
+                  description: resource.description,
+                  hasAnonymizedContent: resource.hasAnonymizedContent,
+                },
+              }),
+              analysisStoreLoadRemoteTimelineSuccess(),
+            ),
+          ),
+          catchError(error =>
+            of(analysisStoreLoadRemoteTimelineFailure({ error: error?.message ?? 'Timeline loading failed' })),
+          ),
+        ),
+      ),
     ),
   );
 }

--- a/src/app/store/AnalysisStore/analysis-store.reducer.ts
+++ b/src/app/store/AnalysisStore/analysis-store.reducer.ts
@@ -2,8 +2,20 @@ import { createReducer, on } from '@ngrx/store';
 import { AnalysisStoreVisibility, PanelResourceResponse, TimelineResourceResponse } from '../../interfaces/analysis-store';
 import { SequencerPanel } from '../../interfaces/sequencer-panel.interface';
 import {
+  analysisStoreExportTimeline,
+  analysisStoreExportTimelineFailure,
+  analysisStoreExportTimelineSuccess,
   analysisStoreHydratePanelFromValidatedPayload,
   analysisStoreHydrateTimelineResourceMeta,
+  analysisStoreImportTimeline,
+  analysisStoreImportTimelineFailure,
+  analysisStoreImportTimelineSuccess,
+  analysisStoreLoadRemoteTimeline,
+  analysisStoreLoadRemoteTimelineFailure,
+  analysisStoreLoadRemoteTimelineSuccess,
+  analysisStoreLoadTimelineList,
+  analysisStoreLoadTimelineListFailure,
+  analysisStoreLoadTimelineListSuccess,
   analysisStoreSavePanel,
   analysisStoreSavePanelFailure,
   analysisStoreSavePanelSuccess,
@@ -30,6 +42,11 @@ export interface AnalysisStoreState {
     error: string | null;
   };
   timeline: AnalysisStoreResourceMetaState & {
+    resources: TimelineResourceResponse[];
+    isLoadingList: boolean;
+    isLoadingRemote: boolean;
+    isImporting: boolean;
+    isExporting: boolean;
     isSaving: boolean;
     error: string | null;
   };
@@ -56,6 +73,11 @@ export const initialAnalysisStoreState: AnalysisStoreState = {
   timeline: {
     ...initialResourceMetaState,
     title: 'Timeline',
+    resources: [],
+    isLoadingList: false,
+    isLoadingRemote: false,
+    isImporting: false,
+    isExporting: false,
     isSaving: false,
     error: null,
   },
@@ -147,6 +169,103 @@ export const analysisStoreReducer = createReducer(
     timeline: {
       ...state.timeline,
       isSaving: false,
+      error,
+    },
+  })),
+  on(analysisStoreImportTimeline, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isImporting: true,
+      error: null,
+    },
+  })),
+  on(analysisStoreImportTimelineSuccess, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isImporting: false,
+      error: null,
+    },
+  })),
+  on(analysisStoreImportTimelineFailure, (state, { error }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isImporting: false,
+      error,
+    },
+  })),
+  on(analysisStoreExportTimeline, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isExporting: true,
+      error: null,
+    },
+  })),
+  on(analysisStoreExportTimelineSuccess, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isExporting: false,
+      error: null,
+    },
+  })),
+  on(analysisStoreExportTimelineFailure, (state, { error }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isExporting: false,
+      error,
+    },
+  })),
+  on(analysisStoreLoadTimelineList, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isLoadingList: true,
+      error: null,
+    },
+  })),
+  on(analysisStoreLoadTimelineListSuccess, (state, { resources }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      resources,
+      isLoadingList: false,
+      error: null,
+    },
+  })),
+  on(analysisStoreLoadTimelineListFailure, (state, { error }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isLoadingList: false,
+      error,
+    },
+  })),
+  on(analysisStoreLoadRemoteTimeline, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isLoadingRemote: true,
+      error: null,
+    },
+  })),
+  on(analysisStoreLoadRemoteTimelineSuccess, state => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isLoadingRemote: false,
+      error: null,
+    },
+  })),
+  on(analysisStoreLoadRemoteTimelineFailure, (state, { error }) => ({
+    ...state,
+    timeline: {
+      ...state.timeline,
+      isLoadingRemote: false,
       error,
     },
   })),

--- a/src/app/store/AnalysisStore/analysis-store.selectors.ts
+++ b/src/app/store/AnalysisStore/analysis-store.selectors.ts
@@ -17,6 +17,20 @@ export const selectCurrentTimelineResourceId = createSelector(
   timelineState => timelineState.currentResourceId,
 );
 
+export const selectAnalysisStoreTimelineResources = createSelector(
+  selectAnalysisStoreTimelineState,
+  timelineState => timelineState.resources,
+);
+
+export const selectAnalysisStoreTimelineOps = createSelector(selectAnalysisStoreTimelineState, timelineState => ({
+  isLoadingList: timelineState.isLoadingList,
+  isLoadingRemote: timelineState.isLoadingRemote,
+  isImporting: timelineState.isImporting,
+  isExporting: timelineState.isExporting,
+  isSaving: timelineState.isSaving,
+  error: timelineState.error,
+}));
+
 export const selectHasCurrentPanelContent = createSelector(
   selectAnalysisStorePanelState,
   panelState => !!panelState.currentContent && panelState.currentContent.btnList.length > 0,

--- a/src/app/utils/timeline/timeline-import.util.ts
+++ b/src/app/utils/timeline/timeline-import.util.ts
@@ -1,0 +1,71 @@
+import { AnalysisTimelineV1 } from '../../interfaces/analysis-store';
+import { TimelineState } from '../../store/Timeline/timeline.reducer';
+
+export function hasTimelineImportDataLoss(currentTimeline: TimelineState, nextTimeline: AnalysisTimelineV1): boolean {
+  const hasCurrentData =
+    currentTimeline.definitions.eventDefs.length > 0 ||
+    currentTimeline.definitions.labelDefs.length > 0 ||
+    currentTimeline.occurrences.length > 0;
+
+  if (!hasCurrentData) {
+    return false;
+  }
+
+  const nextEventIds = new Set(nextTimeline.eventDefs.map(definition => definition.id));
+  const nextLabelIds = new Set(nextTimeline.labelDefs.map(definition => definition.id));
+  const nextOccurrenceIds = new Set(nextTimeline.occurrences.map(occurrence => occurrence.id));
+
+  const eventLoss = currentTimeline.definitions.eventDefs.some(definition => !nextEventIds.has(definition.id));
+  const labelLoss = currentTimeline.definitions.labelDefs.some(definition => !nextLabelIds.has(definition.id));
+  const occurrenceLoss = currentTimeline.occurrences.some(occurrence => !nextOccurrenceIds.has(occurrence.id));
+
+  return eventLoss || labelLoss || occurrenceLoss;
+}
+
+export function hasTimelineImportDataLossFromRawPayload(
+  currentTimeline: TimelineState,
+  rawPayload: Record<string, unknown>,
+): boolean {
+  const eventDefs = Array.isArray(rawPayload['eventDefs']) ? rawPayload['eventDefs'] : [];
+  const labelDefs = Array.isArray(rawPayload['labelDefs']) ? rawPayload['labelDefs'] : [];
+  const occurrences = Array.isArray(rawPayload['occurrences']) ? rawPayload['occurrences'] : [];
+
+  const normalizedNext: AnalysisTimelineV1 = {
+    schemaVersion: '1.0.0',
+    type: 'analysis-timeline',
+    timelineName: typeof rawPayload['timelineName'] === 'string' ? rawPayload['timelineName'] : 'Timeline',
+    meta: {
+      createdAtIso: new Date().toISOString(),
+      updatedAtIso: new Date().toISOString(),
+      exportedAtIso: new Date().toISOString(),
+      sourceUserId: null,
+      sourceApp: 'front-service',
+      sourceAppVersion: 'unknown',
+    },
+    eventDefs: eventDefs
+      .map(item => (typeof item === 'object' && item ? item : null))
+      .filter((item): item is { id: string; name?: string; colorHex?: string | null } => !!item && typeof item.id === 'string')
+      .map(item => ({ id: item.id, name: item.name ?? item.id, colorHex: item.colorHex ?? null })),
+    labelDefs: labelDefs
+      .map(item => (typeof item === 'object' && item ? item : null))
+      .filter((item): item is { id: string; name?: string; colorHex?: string | null } => !!item && typeof item.id === 'string')
+      .map(item => ({ id: item.id, name: item.name ?? item.id, colorHex: item.colorHex ?? null })),
+    occurrences: occurrences
+      .map(item => (typeof item === 'object' && item ? item : null))
+      .filter(
+        (item): item is { id: string; eventDefId?: string | null; labelDefId?: string | null; occurredAtIso?: string; durationMs?: number; note?: string | null } =>
+          !!item && typeof item.id === 'string',
+      )
+      .map(item => ({
+        id: item.id,
+        eventDefId: item.eventDefId ?? null,
+        labelDefId: item.labelDefId ?? null,
+        occurredAtIso: item.occurredAtIso ?? new Date().toISOString(),
+        durationMs: typeof item.durationMs === 'number' ? item.durationMs : 0,
+        note: item.note ?? null,
+      })),
+    ui: { zoom: 1, showLabels: true, selectedOccurrenceId: null },
+  };
+
+  return hasTimelineImportDataLoss(currentTimeline, normalizedNext);
+}


### PR DESCRIPTION
### Motivation
- Centraliser la persistance et les échanges JSON de la timeline via le store `analysis-store` en répliquant la logique déjà utilisée pour les panels (action -> effect -> reducer). 
- Permettre import local validé, export JSON métier, sauvegarde privée (create/update) et chargement de timelines distantes owner-only avec confirmation avant écrasement. 

### Description
- Ajout d'actions NgRx pour la timeline dans `analysis-store` : import/ importSuccess/importFailure, export/exportSuccess/exportFailure, load list/load remote (+ success/failure) et load remote action (`src/app/store/AnalysisStore/analysis-store.actions.ts`).
- Extension du reducer `analysis-store` pour suivre la liste distante et les états opérationnels (`resources`, `isLoadingList`, `isLoadingRemote`, `isImporting`, `isExporting`, `isSaving`, `error`) et hydrater `currentResourceId` après save/load (`src/app/store/AnalysisStore/analysis-store.reducer.ts`).
- Ajout de selectors pour piloter l'UI (`selectAnalysisStoreTimelineResources`, `selectAnalysisStoreTimelineOps`) et réutilisation des mappers timeline existants dans les effects (`src/app/store/AnalysisStore/analysis-store.selectors.ts`, `src/app/store/AnalysisStore/analysis-store.effects.ts`).
- Implementation des effects : validation d'import via `/api/imports/timelines/validate` (usage de `normalizedPayload`), export JSON depuis l'état front courant (download), listing et chargement distant via routes timelines owner-only, et hydratation front/meta à la réception (`src/app/store/AnalysisStore/analysis-store.effects.ts`).
- Branché l'UI timeline : bouton `save`, menu `import/export`, action `load distant` avec une modale `TimelineFinderDialog` pour choisir la resource distante, et import via input fichier JSON caché (validation + confirmation perte de données) (`src/app/components/analyse/timeline/timeline.component.ts`, `src/app/components/analyse/timeline/timeline.component.html`, `src/app/components/analyse/timeline/modals/timeline-finder-dialog.*`).
- Ajout d'un utilitaire pour détecter la perte de données à l'import (comparaison defs/occurrences) et décider d'une confirmation d'écrasement (`src/app/utils/timeline/timeline-import.util.ts`).

### Testing
- `npm run lint` — succeeded (tous les fichiers passent le lint). 
- `npm run build` — succeeded (build complet, génération des bundles).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de41afd07c83268e693c3209535dde)