### PR TITLE
fix: route analysis-store through /analysis public prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ npm ci
 npm start
 ```
 - Frontend: `http://localhost:4200`
-- Le mode dev utilise `proxy.conf.mjs` pour proxifier `/auth`, `/users`, `/me` vers `http://localhost:3000`.
+- Le mode dev utilise `proxy.conf.mjs` pour proxifier :
+  - `/auth`, `/users`, `/me` vers `http://localhost:3000` (auth-service)
+  - `/analysis/api/...` vers `http://localhost:3001/api/...` (analysis-store-service, via strip du préfixe `/analysis`)
+- En production, le proxy Angular n'est pas utilisé : Traefik doit router publiquement `/analysis/...` vers analysis-store-service.
 
 ## Build local
 ```bash

--- a/contract/deployment/reverse-proxy.md
+++ b/contract/deployment/reverse-proxy.md
@@ -10,6 +10,7 @@
 - Toutes les routes frontend (`/`, `/discover`, `/analyse`, etc.) doivent pointer vers le front.
 - Les routes API backend peuvent être routées séparément par Traefik.
 - Si le front consomme des endpoints relatifs (`/auth`, `/users`, `/me`), Traefik doit les router vers le backend approprié.
+- Analysis-store: le front consomme publiquement `/analysis/api/...`; Traefik doit router ce préfixe vers `analysis-store-service` (avec strip-prefix `/analysis` si le service expose `/api/...` en interne).
 
 ## Deep-link / refresh
 - En SSR, un refresh sur une route profonde fonctionne si Traefik transfère la requête telle quelle au serveur front.

--- a/contract/deployment/runtime-env.example
+++ b/contract/deployment/runtime-env.example
@@ -13,5 +13,9 @@ AUTH_REFRESH_ENDPOINT=/auth/refresh
 AUTH_LOGOUT_ENDPOINT=/auth/logout
 AUTH_ME_ENDPOINT=/me
 
+# Préfixe public analysis-store utilisé par le front (Traefik),
+# le service backend conserve ses routes internes en /api.
+ANALYSIS_STORE_API_PREFIX=/analysis
+
 # Préfixes autorisés pour l'injection automatique du bearer token (CSV)
-API_ALLOWED_PREFIXES=/auth,/api,/me,/users
+API_ALLOWED_PREFIXES=/auth,/analysis/api,/api,/me,/users

--- a/proxy.conf.mjs
+++ b/proxy.conf.mjs
@@ -6,8 +6,8 @@
  *   le cookie refresh `Path=/auth`.
  *
  * Analysis-store-service (localhost:3001)
- * - Router uniquement les routes réellement utilisées par le front,
- *   sans capturer globalement tout `/api` (évite les collisions inter-services).
+ * - Le front appelle le préfixe public `/analysis/api/...` (même contrat qu'en prod derrière Traefik).
+ * - En dev, le proxy retire `/analysis` pour cibler le service local qui expose ses routes internes en `/api/...`.
  */
 export default {
   // auth-service
@@ -28,19 +28,22 @@ export default {
   },
 
   // analysis-store-service
-  '/api/imports': {
+  '/analysis/api/imports': {
     target: 'http://localhost:3001',
     secure: false,
     changeOrigin: true,
+    pathRewrite: { '^/analysis': '' },
   },
-  '/api/timelines': {
+  '/analysis/api/timelines': {
     target: 'http://localhost:3001',
     secure: false,
     changeOrigin: true,
+    pathRewrite: { '^/analysis': '' },
   },
-  '/api/panels': {
+  '/analysis/api/panels': {
     target: 'http://localhost:3001',
     secure: false,
     changeOrigin: true,
+    pathRewrite: { '^/analysis': '' },
   },
 };

--- a/src/app/core/config/runtime-environment.ts
+++ b/src/app/core/config/runtime-environment.ts
@@ -53,13 +53,14 @@ function readServerRuntimeConfig(): RuntimeConfigShape {
   }
 
   const authPrefix = process.env['AUTH_API_PREFIX']?.trim() || '';
-  const analysisStorePrefix = process.env['ANALYSIS_STORE_API_PREFIX']?.trim() || '';
+  const analysisStorePrefix = process.env['ANALYSIS_STORE_API_PREFIX']?.trim() || environment.analysisStoreApiPrefix;
 
   return {
     analysisStoreDevHeadersEnabled: parseBoolean(
       process.env['ANALYSIS_STORE_DEV_HEADERS_ENABLED'],
       environment.analysisStoreDevHeadersEnabled,
     ),
+    analysisStoreApiPrefix: analysisStorePrefix,
     apiAllowedPrefixes: parseCsv(process.env['API_ALLOWED_PREFIXES'], environment.apiAllowedPrefixes),
     authEndpoints: {
       login: process.env['AUTH_LOGIN_ENDPOINT'] || `${authPrefix}/auth/login`,
@@ -86,6 +87,7 @@ function mergeWithDefaults(runtimeConfig: RuntimeConfigShape): AppEnvironment {
     production: environment.production,
     analysisStoreDevHeadersEnabled:
       runtimeConfig.analysisStoreDevHeadersEnabled ?? environment.analysisStoreDevHeadersEnabled,
+    analysisStoreApiPrefix: runtimeConfig.analysisStoreApiPrefix ?? environment.analysisStoreApiPrefix,
     apiAllowedPrefixes: runtimeConfig.apiAllowedPrefixes ?? environment.apiAllowedPrefixes,
     authEndpoints: {
       login: runtimeConfig.authEndpoints?.login ?? environment.authEndpoints.login,

--- a/src/app/core/interceptors/analysis-store-dev-auth.interceptor.spec.ts
+++ b/src/app/core/interceptors/analysis-store-dev-auth.interceptor.spec.ts
@@ -11,10 +11,13 @@ describe('analysisStoreDevAuthInterceptor', () => {
   let httpMock: HttpTestingController;
   let authSessionMock: { user: jasmine.Spy };
   let previousEnabled: boolean;
+  let previousApiPrefix: string;
 
   beforeEach(() => {
     previousEnabled = runtimeEnvironment.analysisStoreDevHeadersEnabled;
+    previousApiPrefix = runtimeEnvironment.analysisStoreApiPrefix;
     runtimeEnvironment.analysisStoreDevHeadersEnabled = true;
+    runtimeEnvironment.analysisStoreApiPrefix = '/analysis';
 
     authSessionMock = {
       user: jasmine.createSpy('user').and.returnValue({ id: 'user-123', pseudo: 'coach', email: 'coach@ab.fr' }),
@@ -34,13 +37,14 @@ describe('analysisStoreDevAuthInterceptor', () => {
 
   afterEach(() => {
     runtimeEnvironment.analysisStoreDevHeadersEnabled = previousEnabled;
+    runtimeEnvironment.analysisStoreApiPrefix = previousApiPrefix;
     httpMock.verify();
   });
 
   it('injects x-auth-user-id on protected analysis-store routes', () => {
-    http.get('/api/panels').subscribe();
+    http.get('/analysis/api/panels').subscribe();
 
-    const req = httpMock.expectOne('/api/panels');
+    const req = httpMock.expectOne('/analysis/api/panels');
     expect(req.request.headers.get('x-auth-user-id')).toBe('user-123');
     req.flush([]);
   });
@@ -56,19 +60,19 @@ describe('analysisStoreDevAuthInterceptor', () => {
   it('does not inject invalid header when user is unavailable', () => {
     authSessionMock.user.and.returnValue(null);
 
-    http.get('/api/timelines').subscribe();
+    http.get('/analysis/api/timelines').subscribe();
 
-    const req = httpMock.expectOne('/api/timelines');
+    const req = httpMock.expectOne('/analysis/api/timelines');
     expect(req.request.headers.has('x-auth-user-id')).toBeFalse();
     req.flush([]);
   });
 
   it('keeps existing x-auth-user-id header untouched', () => {
-    http.get('/api/imports/timelines/validate', {
+    http.get('/analysis/api/imports/timelines/validate', {
       headers: { 'x-auth-user-id': 'manual-user' },
     }).subscribe();
 
-    const req = httpMock.expectOne('/api/imports/timelines/validate');
+    const req = httpMock.expectOne('/analysis/api/imports/timelines/validate');
     expect(req.request.headers.get('x-auth-user-id')).toBe('manual-user');
     req.flush({});
   });
@@ -76,9 +80,9 @@ describe('analysisStoreDevAuthInterceptor', () => {
   it('is disabled when environment flag is false', () => {
     runtimeEnvironment.analysisStoreDevHeadersEnabled = false;
 
-    http.get('/api/panels').subscribe();
+    http.get('/analysis/api/panels').subscribe();
 
-    const req = httpMock.expectOne('/api/panels');
+    const req = httpMock.expectOne('/analysis/api/panels');
     expect(req.request.headers.has('x-auth-user-id')).toBeFalse();
     req.flush([]);
   });

--- a/src/app/core/interceptors/analysis-store-dev-auth.interceptor.ts
+++ b/src/app/core/interceptors/analysis-store-dev-auth.interceptor.ts
@@ -3,7 +3,19 @@ import { inject } from '@angular/core';
 import { AuthSessionService } from '../auth/auth-session.service';
 import { runtimeEnvironment } from '../config/runtime-environment';
 
-const ANALYSIS_STORE_PROTECTED_PREFIXES = ['/api/imports', '/api/panels', '/api/timelines'];
+function normalizePrefix(prefix: string): string {
+  const trimmed = prefix.trim();
+  if (!trimmed) {
+    return '';
+  }
+
+  return trimmed.replace(/\/+$/, '');
+}
+
+function getAnalysisStoreProtectedPrefixes(): string[] {
+  const analysisStoreApiBase = `${normalizePrefix(runtimeEnvironment.analysisStoreApiPrefix)}/api`;
+  return [`${analysisStoreApiBase}/imports`, `${analysisStoreApiBase}/panels`, `${analysisStoreApiBase}/timelines`];
+}
 
 export const analysisStoreDevAuthInterceptor: HttpInterceptorFn = (req, next) => {
   if (!runtimeEnvironment.analysisStoreDevHeadersEnabled || !isAnalysisStoreProtectedUrl(req.url)) {
@@ -29,15 +41,17 @@ function isAnalysisStoreProtectedUrl(url: string): boolean {
     return false;
   }
 
+  const protectedPrefixes = getAnalysisStoreProtectedPrefixes();
+
   if (!/^https?:\/\//i.test(url)) {
-    return ANALYSIS_STORE_PROTECTED_PREFIXES.some(prefix => url.startsWith(prefix));
+    return protectedPrefixes.some(prefix => url.startsWith(prefix));
   }
 
   try {
     const parsed = new URL(url);
     const isSameOrigin = typeof window !== 'undefined' ? parsed.origin === window.location.origin : false;
 
-    return isSameOrigin && ANALYSIS_STORE_PROTECTED_PREFIXES.some(prefix => parsed.pathname.startsWith(prefix));
+    return isSameOrigin && protectedPrefixes.some(prefix => parsed.pathname.startsWith(prefix));
   } catch {
     return false;
   }

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -4,10 +4,13 @@ import { AppEnvironment } from './environment.model';
  * En développement local on cible le proxy Angular.
  * Cela permet de travailler sans Traefik tout en gardant les mêmes chemins (`/auth`, `/me`, `/users`).
  */
+const ANALYSIS_STORE_API_PREFIX = '/analysis';
+
 export const environment: AppEnvironment = {
   production: false,
   analysisStoreDevHeadersEnabled: true,
-  apiAllowedPrefixes: ['/auth', '/api', '/me', '/users'],
+  analysisStoreApiPrefix: ANALYSIS_STORE_API_PREFIX,
+  apiAllowedPrefixes: ['/auth', '/analysis/api', '/api', '/me', '/users'],
   authEndpoints: {
     login: '/auth/login',
     register: '/users',
@@ -16,9 +19,9 @@ export const environment: AppEnvironment = {
     me: '/me',
   },
   analysisStoreEndpoints: {
-    importsTimelinesValidate: '/api/imports/timelines/validate',
-    importsPanelsValidate: '/api/imports/panels/validate',
-    timelines: '/api/timelines',
-    panels: '/api/panels',
+    importsTimelinesValidate: `${ANALYSIS_STORE_API_PREFIX}/api/imports/timelines/validate`,
+    importsPanelsValidate: `${ANALYSIS_STORE_API_PREFIX}/api/imports/panels/validate`,
+    timelines: `${ANALYSIS_STORE_API_PREFIX}/api/timelines`,
+    panels: `${ANALYSIS_STORE_API_PREFIX}/api/panels`,
   },
 };

--- a/src/environments/environment.model.ts
+++ b/src/environments/environment.model.ts
@@ -1,6 +1,7 @@
 export interface AppEnvironment {
   production: boolean;
   analysisStoreDevHeadersEnabled: boolean;
+  analysisStoreApiPrefix: string;
   apiAllowedPrefixes: string[];
   authEndpoints: {
     login: string;

--- a/src/environments/environment.production.ts
+++ b/src/environments/environment.production.ts
@@ -4,10 +4,13 @@ import { AppEnvironment } from './environment.model';
  * En production on conserve des chemins relatifs pour laisser l'infra
  * (Nginx/Traefik) router vers les bons services sans exposer de domaine API en dur.
  */
+const ANALYSIS_STORE_API_PREFIX = '/analysis';
+
 export const environment: AppEnvironment = {
   production: true,
   analysisStoreDevHeadersEnabled: false,
-  apiAllowedPrefixes: ['/auth', '/api', '/me', '/users'],
+  analysisStoreApiPrefix: ANALYSIS_STORE_API_PREFIX,
+  apiAllowedPrefixes: ['/auth', '/analysis/api', '/api', '/me', '/users'],
   authEndpoints: {
     login: '/auth/login',
     register: '/users',
@@ -16,9 +19,9 @@ export const environment: AppEnvironment = {
     me: '/me',
   },
   analysisStoreEndpoints: {
-    importsTimelinesValidate: '/api/imports/timelines/validate',
-    importsPanelsValidate: '/api/imports/panels/validate',
-    timelines: '/api/timelines',
-    panels: '/api/panels',
+    importsTimelinesValidate: `${ANALYSIS_STORE_API_PREFIX}/api/imports/timelines/validate`,
+    importsPanelsValidate: `${ANALYSIS_STORE_API_PREFIX}/api/imports/panels/validate`,
+    timelines: `${ANALYSIS_STORE_API_PREFIX}/api/timelines`,
+    panels: `${ANALYSIS_STORE_API_PREFIX}/api/panels`,
   },
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,9 +1,12 @@
 import { AppEnvironment } from './environment.model';
 
+const ANALYSIS_STORE_API_PREFIX = '/analysis';
+
 export const environment: AppEnvironment = {
   production: false,
   analysisStoreDevHeadersEnabled: true,
-  apiAllowedPrefixes: ['/auth', '/api', '/me', '/users'],
+  analysisStoreApiPrefix: ANALYSIS_STORE_API_PREFIX,
+  apiAllowedPrefixes: ['/auth', '/analysis/api', '/api', '/me', '/users'],
   authEndpoints: {
     login: '/auth/login',
     register: '/users',
@@ -12,9 +15,9 @@ export const environment: AppEnvironment = {
     me: '/me',
   },
   analysisStoreEndpoints: {
-    importsTimelinesValidate: '/api/imports/timelines/validate',
-    importsPanelsValidate: '/api/imports/panels/validate',
-    timelines: '/api/timelines',
-    panels: '/api/panels',
+    importsTimelinesValidate: `${ANALYSIS_STORE_API_PREFIX}/api/imports/timelines/validate`,
+    importsPanelsValidate: `${ANALYSIS_STORE_API_PREFIX}/api/imports/panels/validate`,
+    timelines: `${ANALYSIS_STORE_API_PREFIX}/api/timelines`,
+    panels: `${ANALYSIS_STORE_API_PREFIX}/api/panels`,
   },
 };


### PR DESCRIPTION
### Motivation
- Production must not call analysis-store internal routes as `/api/...` directly but use a clean public prefix routed by Traefik (e.g. `/analysis/api/...`).
- Centralize the public prefix so the front can build analysis-store endpoints consistently for both SSR and browser environments without relying on the Angular dev proxy.

### Description
- Add `analysisStoreApiPrefix` to the environment model and set `ANALYSIS_STORE_API_PREFIX` in `src/environments/*` so analysis-store endpoints are built as `${prefix}/api/...` across default/dev/prod.
- Update `src/app/core/config/runtime-environment.ts` to read `ANALYSIS_STORE_API_PREFIX` (server runtime config fallback) and expose it via `runtimeEnvironment` for SSR and browser code.
- Replace hardcoded analysis-store paths in the dev auth interceptor by computing protected prefixes from `runtimeEnvironment.analysisStoreApiPrefix`, and update the interceptor logic accordingly.
- Update the interceptor unit test to assert against the new public paths (`/analysis/api/...`) and restore/cleanup the runtime prefix during the test.
- Change `proxy.conf.mjs` to proxy `/analysis/api/*` to the local analysis-store (`http://localhost:3001/api/*`) using `pathRewrite` so dev workflow stays compatible with the new public prefix.
- Update documentation (`README.md`, `contract/deployment/*`) and `runtime-env.example` to explain the public `/analysis/...` contract and the dev proxy behavior; add `/analysis/api` to allowed API prefixes while keeping `/api` for other services.

### Testing
- Ran `npm run lint` and it completed successfully (`All files pass linting`).
- Ran the interceptor unit test via `ng test --include=src/app/core/interceptors/analysis-store-dev-auth.interceptor.spec.ts` which failed type-checking due to the test environment not recognizing `process` (TS error about missing Node types), an existing type-check constraint surfaced during the run and not functionally related to the routing change.
- No other automated test suites were modified or executed in this change set. Please run full CI (`npm test`, build) in the project environment where Node types are available to confirm unit tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e488f4781c8326ab035caacfa3a908)