### PR TITLE
Fix runtime-config.js generation for analysis-store endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ npm start
   - `/auth`, `/users`, `/me` vers `http://localhost:3000` (auth-service)
   - `/analysis/api/...` vers `http://localhost:3001/api/...` (analysis-store-service, via strip du préfixe `/analysis`)
 - En production, le proxy Angular n'est pas utilisé : Traefik doit router publiquement `/analysis/...` vers analysis-store-service.
+- En SSR/prod, `/runtime-config.js` est généré dynamiquement par `src/server.ts` à partir des variables d'environnement + des valeurs `environment` Angular.
+- Le navigateur lit `window.__RUNTIME_CONFIG__` pour résoudre les endpoints publics relatifs (dont analysis-store en `/analysis/api/...`).
+- Le proxy Angular (`proxy.conf.mjs`) reste réservé au développement local.
 
 ## Build local
 ```bash

--- a/src/app/core/config/runtime-config-builder.ts
+++ b/src/app/core/config/runtime-config-builder.ts
@@ -1,0 +1,99 @@
+import { AppEnvironment } from '../../../environments/environment.model';
+
+export type RuntimeConfigShape = Partial<Omit<AppEnvironment, 'production'>>;
+
+export type RuntimeEnvironmentVariables = Record<string, string | undefined>;
+
+export function parseCsv(value: string | undefined, fallback: string[]): string[] {
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+
+  return parsed.length > 0 ? parsed : fallback;
+}
+
+export function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value == null) {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on') {
+    return true;
+  }
+
+  if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'off') {
+    return false;
+  }
+
+  return fallback;
+}
+
+export function buildRuntimeConfigFromEnv(
+  runtimeEnv: RuntimeEnvironmentVariables,
+  defaults: AppEnvironment,
+): RuntimeConfigShape {
+  const authPrefix = runtimeEnv['AUTH_API_PREFIX']?.trim() || '';
+  const analysisStorePrefix = runtimeEnv['ANALYSIS_STORE_API_PREFIX']?.trim() || defaults.analysisStoreApiPrefix;
+
+  return {
+    analysisStoreDevHeadersEnabled: parseBoolean(
+      runtimeEnv['ANALYSIS_STORE_DEV_HEADERS_ENABLED'],
+      defaults.analysisStoreDevHeadersEnabled,
+    ),
+    analysisStoreApiPrefix: analysisStorePrefix,
+    apiAllowedPrefixes: parseCsv(runtimeEnv['API_ALLOWED_PREFIXES'], defaults.apiAllowedPrefixes),
+    authEndpoints: {
+      login: runtimeEnv['AUTH_LOGIN_ENDPOINT'] || `${authPrefix}/auth/login`,
+      register: runtimeEnv['AUTH_REGISTER_ENDPOINT'] || `${authPrefix}/users`,
+      refresh: runtimeEnv['AUTH_REFRESH_ENDPOINT'] || `${authPrefix}/auth/refresh`,
+      logout: runtimeEnv['AUTH_LOGOUT_ENDPOINT'] || `${authPrefix}/auth/logout`,
+      me: runtimeEnv['AUTH_ME_ENDPOINT'] || `${authPrefix}/me`,
+    },
+    analysisStoreEndpoints: {
+      importsTimelinesValidate:
+        runtimeEnv['ANALYSIS_STORE_IMPORTS_TIMELINES_VALIDATE_ENDPOINT'] ||
+        `${analysisStorePrefix}/api/imports/timelines/validate`,
+      importsPanelsValidate:
+        runtimeEnv['ANALYSIS_STORE_IMPORTS_PANELS_VALIDATE_ENDPOINT'] ||
+        `${analysisStorePrefix}/api/imports/panels/validate`,
+      timelines: runtimeEnv['ANALYSIS_STORE_TIMELINES_ENDPOINT'] || `${analysisStorePrefix}/api/timelines`,
+      panels: runtimeEnv['ANALYSIS_STORE_PANELS_ENDPOINT'] || `${analysisStorePrefix}/api/panels`,
+    },
+  };
+}
+
+export function mergeRuntimeConfigWithDefaults(
+  runtimeConfig: RuntimeConfigShape,
+  defaults: AppEnvironment,
+): AppEnvironment {
+  return {
+    production: defaults.production,
+    analysisStoreDevHeadersEnabled:
+      runtimeConfig.analysisStoreDevHeadersEnabled ?? defaults.analysisStoreDevHeadersEnabled,
+    analysisStoreApiPrefix: runtimeConfig.analysisStoreApiPrefix ?? defaults.analysisStoreApiPrefix,
+    apiAllowedPrefixes: runtimeConfig.apiAllowedPrefixes ?? defaults.apiAllowedPrefixes,
+    authEndpoints: {
+      login: runtimeConfig.authEndpoints?.login ?? defaults.authEndpoints.login,
+      register: runtimeConfig.authEndpoints?.register ?? defaults.authEndpoints.register,
+      refresh: runtimeConfig.authEndpoints?.refresh ?? defaults.authEndpoints.refresh,
+      logout: runtimeConfig.authEndpoints?.logout ?? defaults.authEndpoints.logout,
+      me: runtimeConfig.authEndpoints?.me ?? defaults.authEndpoints.me,
+    },
+    analysisStoreEndpoints: {
+      importsTimelinesValidate:
+        runtimeConfig.analysisStoreEndpoints?.importsTimelinesValidate ??
+        defaults.analysisStoreEndpoints.importsTimelinesValidate,
+      importsPanelsValidate:
+        runtimeConfig.analysisStoreEndpoints?.importsPanelsValidate ??
+        defaults.analysisStoreEndpoints.importsPanelsValidate,
+      timelines: runtimeConfig.analysisStoreEndpoints?.timelines ?? defaults.analysisStoreEndpoints.timelines,
+      panels: runtimeConfig.analysisStoreEndpoints?.panels ?? defaults.analysisStoreEndpoints.panels,
+    },
+  };
+}

--- a/src/app/core/config/runtime-environment.ts
+++ b/src/app/core/config/runtime-environment.ts
@@ -1,42 +1,15 @@
 import { environment } from '../../../environments/environment';
 import { AppEnvironment } from '../../../environments/environment.model';
-
-type RuntimeConfigShape = Partial<Omit<AppEnvironment, 'production'>>;
+import {
+  buildRuntimeConfigFromEnv,
+  mergeRuntimeConfigWithDefaults,
+  RuntimeConfigShape,
+} from './runtime-config-builder';
 
 declare global {
   interface Window {
     __RUNTIME_CONFIG__?: RuntimeConfigShape;
   }
-}
-
-function parseCsv(value: string | undefined, fallback: string[]): string[] {
-  if (!value) {
-    return fallback;
-  }
-
-  const parsed = value
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
-
-  return parsed.length > 0 ? parsed : fallback;
-}
-
-function parseBoolean(value: string | undefined, fallback: boolean): boolean {
-  if (value == null) {
-    return fallback;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on') {
-    return true;
-  }
-
-  if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'off') {
-    return false;
-  }
-
-  return fallback;
 }
 
 function readBrowserRuntimeConfig(): RuntimeConfigShape {
@@ -52,63 +25,9 @@ function readServerRuntimeConfig(): RuntimeConfigShape {
     return {};
   }
 
-  const authPrefix = process.env['AUTH_API_PREFIX']?.trim() || '';
-  const analysisStorePrefix = process.env['ANALYSIS_STORE_API_PREFIX']?.trim() || environment.analysisStoreApiPrefix;
-
-  return {
-    analysisStoreDevHeadersEnabled: parseBoolean(
-      process.env['ANALYSIS_STORE_DEV_HEADERS_ENABLED'],
-      environment.analysisStoreDevHeadersEnabled,
-    ),
-    analysisStoreApiPrefix: analysisStorePrefix,
-    apiAllowedPrefixes: parseCsv(process.env['API_ALLOWED_PREFIXES'], environment.apiAllowedPrefixes),
-    authEndpoints: {
-      login: process.env['AUTH_LOGIN_ENDPOINT'] || `${authPrefix}/auth/login`,
-      register: process.env['AUTH_REGISTER_ENDPOINT'] || `${authPrefix}/users`,
-      refresh: process.env['AUTH_REFRESH_ENDPOINT'] || `${authPrefix}/auth/refresh`,
-      logout: process.env['AUTH_LOGOUT_ENDPOINT'] || `${authPrefix}/auth/logout`,
-      me: process.env['AUTH_ME_ENDPOINT'] || `${authPrefix}/me`,
-    },
-    analysisStoreEndpoints: {
-      importsTimelinesValidate:
-        process.env['ANALYSIS_STORE_IMPORTS_TIMELINES_VALIDATE_ENDPOINT'] ||
-        `${analysisStorePrefix}/api/imports/timelines/validate`,
-      importsPanelsValidate:
-        process.env['ANALYSIS_STORE_IMPORTS_PANELS_VALIDATE_ENDPOINT'] ||
-        `${analysisStorePrefix}/api/imports/panels/validate`,
-      timelines: process.env['ANALYSIS_STORE_TIMELINES_ENDPOINT'] || `${analysisStorePrefix}/api/timelines`,
-      panels: process.env['ANALYSIS_STORE_PANELS_ENDPOINT'] || `${analysisStorePrefix}/api/panels`,
-    },
-  };
-}
-
-function mergeWithDefaults(runtimeConfig: RuntimeConfigShape): AppEnvironment {
-  return {
-    production: environment.production,
-    analysisStoreDevHeadersEnabled:
-      runtimeConfig.analysisStoreDevHeadersEnabled ?? environment.analysisStoreDevHeadersEnabled,
-    analysisStoreApiPrefix: runtimeConfig.analysisStoreApiPrefix ?? environment.analysisStoreApiPrefix,
-    apiAllowedPrefixes: runtimeConfig.apiAllowedPrefixes ?? environment.apiAllowedPrefixes,
-    authEndpoints: {
-      login: runtimeConfig.authEndpoints?.login ?? environment.authEndpoints.login,
-      register: runtimeConfig.authEndpoints?.register ?? environment.authEndpoints.register,
-      refresh: runtimeConfig.authEndpoints?.refresh ?? environment.authEndpoints.refresh,
-      logout: runtimeConfig.authEndpoints?.logout ?? environment.authEndpoints.logout,
-      me: runtimeConfig.authEndpoints?.me ?? environment.authEndpoints.me,
-    },
-    analysisStoreEndpoints: {
-      importsTimelinesValidate:
-        runtimeConfig.analysisStoreEndpoints?.importsTimelinesValidate ??
-        environment.analysisStoreEndpoints.importsTimelinesValidate,
-      importsPanelsValidate:
-        runtimeConfig.analysisStoreEndpoints?.importsPanelsValidate ??
-        environment.analysisStoreEndpoints.importsPanelsValidate,
-      timelines: runtimeConfig.analysisStoreEndpoints?.timelines ?? environment.analysisStoreEndpoints.timelines,
-      panels: runtimeConfig.analysisStoreEndpoints?.panels ?? environment.analysisStoreEndpoints.panels,
-    },
-  };
+  return buildRuntimeConfigFromEnv(process.env, environment);
 }
 
 const runtimeConfig = typeof window === 'undefined' ? readServerRuntimeConfig() : readBrowserRuntimeConfig();
 
-export const runtimeEnvironment: AppEnvironment = mergeWithDefaults(runtimeConfig);
+export const runtimeEnvironment: AppEnvironment = mergeRuntimeConfigWithDefaults(runtimeConfig, environment);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,8 @@ import express from 'express';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import bootstrap from './main.server';
+import { buildRuntimeConfigFromEnv } from './app/core/config/runtime-config-builder';
+import { environment } from './environments/environment';
 
 const serverDistFolder = dirname(fileURLToPath(import.meta.url));
 const browserDistFolder = resolve(serverDistFolder, '../browser');
@@ -17,8 +19,11 @@ app.get('/healthz', (_req, res) => {
 });
 
 app.get('/runtime-config.js', (_req, res) => {
+  const runtimeConfig = buildRuntimeConfigFromEnv(process.env, environment);
+
   res.setHeader('Cache-Control', 'no-store, max-age=0');
-  res.sendFile(join(browserDistFolder, 'runtime-config.js'));
+  res.type('application/javascript');
+  res.send(`window.__RUNTIME_CONFIG__ = ${JSON.stringify(runtimeConfig)};`);
 });
 
 /**


### PR DESCRIPTION
### Motivation
- The browser was receiving an outdated static `/runtime-config.js` that lacked the analysis-store keys, causing client requests to go to `/api/...` instead of `/analysis/api/...`. 
- The goal is to provide a single source of truth so SSR and the browser use identical runtime config built from `process.env` with safe Angular `environment` fallbacks.

### Description
- Added a shared builder `src/app/core/config/runtime-config-builder.ts` to construct the runtime config from environment variables with typed fallbacks to Angular `environment` values (includes `analysisStoreApiPrefix`, `analysisStoreDevHeadersEnabled`, `apiAllowedPrefixes`, `authEndpoints`, and full `analysisStoreEndpoints`).
- Replaced in-memory server/browser duplication by wiring `src/app/core/config/runtime-environment.ts` to use the shared builder and merge logic so SSR/browser resolution follow the same rules.
- Replaced static serving of `public/runtime-config.js` with dynamic generation in `src/server.ts` where `/runtime-config.js` now returns `window.__RUNTIME_CONFIG__ = {...}` using `buildRuntimeConfigFromEnv(process.env, environment)`, served with `Cache-Control: no-store, max-age=0` and `Content-Type: application/javascript`.
- Updated `README.md` with a short note explaining that `/runtime-config.js` is generated dynamically in SSR/prod and that the browser reads `window.__RUNTIME_CONFIG__` for public relative endpoints.

### Testing
- Ran `npm run build` which completed and produced `dist/front-service` (prerender warnings present but build finished successfully).
- Started the built SSR server and fetched the runtime script with `PORT=4100 node dist/front-service/server/server.mjs` and `curl` and verified the response had `Cache-Control: no-store, max-age=0` and `Content-Type: application/javascript`.
- Verified the generated payload includes the required keys and defaults: `window.__RUNTIME_CONFIG__.analysisStoreEndpoints.panels === '/analysis/api/panels'` and `apiAllowedPrefixes` contains `'/analysis/api'`.
- No automated tests were intentionally modified; the existing build plus runtime fetch validation succeeded as described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e49711990883269011cee8930a0229)