### PR TITLE
Restrict GHCR publication to stable SemVer tags on prod history

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -2,8 +2,8 @@ name: Publish image
 
 on:
   push:
-    branches:
-      - prod
+    tags:
+      - 'v*.*.*'
 
 concurrency:
   group: publish-image-${{ github.ref }}
@@ -19,6 +19,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate stable SemVer tag
+        run: |
+          if [[ ! "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag invalide: ${GITHUB_REF_NAME}. Seuls les tags stables SemVer (vX.Y.Z) sont autorisés."
+            exit 1
+          fi
+
+      - name: Ensure tagged commit is on origin/prod
+        run: |
+          git fetch --no-tags origin prod
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" "origin/prod"; then
+            echo "Le commit taggé (${GITHUB_SHA}) n'appartient pas à l'historique de origin/prod."
+            exit 1
+          fi
 
       - name: Resolve image coordinates
         id: image
@@ -44,7 +61,7 @@ jobs:
         with:
           images: ${{ steps.image.outputs.name }}
           tags: |
-            type=raw,value=prod
+            type=raw,value=${{ github.ref_name }}
             type=raw,value=sha-${{ github.sha }}
           labels: |
             org.opencontainers.image.title=front-service
@@ -66,7 +83,7 @@ jobs:
             echo "## GHCR publication"
             echo
             echo "- Image: \`${{ steps.image.outputs.name }}\`"
-            echo "- Tag prod: \`${{ steps.image.outputs.name }}:prod\`"
+            echo "- Tag SemVer: \`${{ steps.image.outputs.name }}:${{ github.ref_name }}\`"
             echo "- Tag sha: \`${{ steps.image.outputs.name }}:sha-${{ github.sha }}\`"
             echo "- Digest final: \`${{ steps.build.outputs.digest }}\`"
             echo


### PR DESCRIPTION
### Motivation
- The existing publish workflow triggered on pushes to `prod`, which can publish images unintentionally from non-release actions. 
- The goal is to publish the front image only for stable SemVer tags (e.g. `v1.2.3`) and to reject prerelease tags. 
- A published tag must reference a commit that is already contained in `origin/prod` to ensure the release is built from the prod history. 

### Description
- Changed the workflow trigger in `.github/workflows/publish-image.yml` from branch pushes to tag pushes using the pattern `v*.*.*`.
- Added a SemVer validation step that enforces the stable tag format with the regex `^v[0-9]+\.[0-9]+\.[0-9]+$` and fails early for non-matching tags.
- Added a guard step that fetches `origin prod` (`git fetch --no-tags origin prod`) and uses `git merge-base --is-ancestor` to ensure the tagged commit is contained in `origin/prod`, failing before build/push if not.
- Set `fetch-depth: 0` on checkout so the workflow can inspect commit ancestry, and updated image metadata to tag the pushed image with `${{ github.ref_name }}` instead of the static `prod` tag.

### Testing
- No automated tests were executed for this change because it only modifies the GitHub Actions workflow file; changes were verified by inspecting the updated workflow file locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa1772ee10832684abe75aeed87624)